### PR TITLE
feat: add support for mdblist urls

### DIFF
--- a/backend/program/settings/models.py
+++ b/backend/program/settings/models.py
@@ -76,7 +76,7 @@ class ListrrModel(Updatable):
 class MdblistModel(Updatable):
     enabled: bool = False
     api_key: str = ""
-    lists: list[int] = []
+    lists: list[int | str] = []
     update_interval: int = 300
 
 


### PR DESCRIPTION
# Pull Request Check List

This PR allows the ability of defining list with the url. Making it easy to copy and paste any list on mdblist into river.

List ids are also still allowed and logic is kept as is

```
mdblist": {
  "update_interval": 300,
  "enabled": true,
  "api_key": "",
  "lists": [
    "https://mdblist.com/lists/hdlists/latest-hd-crime-movies-top-rated-from-1980-to-today",
    2567
  ]
}

```