### PR TITLE
Return of the string type for mdb lists

### DIFF
--- a/backend/program/settings/models.py
+++ b/backend/program/settings/models.py
@@ -83,7 +83,7 @@ class ListrrModel(Updatable):
 class MdblistModel(Updatable):
     enabled: bool = False
     api_key: str = ""
-    lists: List[int] = []
+    lists: List[int | str] = []
     update_interval: int = 300
 
 


### PR DESCRIPTION
Seems it got lost during a merge