### PR TITLE
Bugfix - Fetch all pages unless limit is set

### DIFF
--- a/backend/program/content/trakt.py
+++ b/backend/program/content/trakt.py
@@ -263,7 +263,7 @@ def _fetch_data(url, headers, params):
                 if not data:
                     break
                 all_data.extend(data)
-                if params.get("limit") and len(data) <= params["limit"]:
+                if params.get("limit") and len(all_data) >= params["limit"]:
                     break
                 page += 1
             elif response.status_code == 429:

--- a/backend/program/content/trakt.py
+++ b/backend/program/content/trakt.py
@@ -263,7 +263,7 @@ def _fetch_data(url, headers, params):
                 if not data:
                     break
                 all_data.extend(data)
-                if not params.get("limit") or len(data) <= params["limit"]:
+                if params.get("limit") and len(data) <= params["limit"]:
                     break
                 page += 1
             elif response.status_code == 429:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:

Riven is only fetching the first 10 items of any Trakt collections/lists/watchlist:

```
24-06-18 15:49:02 | 🎵 TRAKT     | trakt.run - New items fetched from Watchlist: 10
24-06-18 15:49:02 | 🎵 TRAKT     | trakt.run - New items fetched from User Lists: 10
24-06-18 15:49:02 | 🎵 TRAKT     | trakt.run - Total new items fetched: 20
```

Now it is fetching all of the items if params.limit is not set:
```
24-06-18 17:02:28 | 🎵 TRAKT     | trakt.run - New items fetched from Watchlist: 14
24-06-18 17:02:28 | 🎵 TRAKT     | trakt.run - New items fetched from User Lists: 25
24-06-18 17:02:28 | 🎵 TRAKT     | trakt.run - Total new items fetched: 39
```