### PR TITLE
feat: support trakt short/share user_lists links

### DIFF
--- a/backend/program/content/trakt.py
+++ b/backend/program/content/trakt.py
@@ -173,20 +173,28 @@ class TraktContent:
 
     def _extract_user_list_from_url(self, url) -> tuple:
         """Extract user and list name from Trakt URL"""
-        # Match full URL format
-        match = regex.match(r'https://trakt.tv/users/([^/]+)/lists/([^/]+)', url)
-        if match:
-            return match.groups()
-        
-        # Match short URL format and resolve to full URL if necessary
+
+        def match_full_url(url: str) -> tuple:
+            """Helper function to match full URL format"""
+            match = regex.match(r'https://trakt.tv/users/([^/]+)/lists/([^/]+)', url)
+            if match:
+                return match.groups()
+            return None, None
+
+        # First try to match the original URL
+        user, list_name = match_full_url(url)
+        if user and list_name:
+            return user, list_name
+
+        # If it's a short URL, resolve it and try to match again
         match = regex.match(r'https://trakt.tv/lists/\d+', url)
         if match:
             full_url = self._resolve_short_url(url)
             if full_url:
-                match = regex.match(r'https://trakt.tv/users/([^/]+)/lists/([^/]+)', full_url)
-                if match:
-                    return match.groups()
-        
+                user, list_name = match_full_url(full_url)
+                if user and list_name:
+                    return user, list_name
+
         return None, None
         
     def _resolve_short_url(self, short_url) -> str or None:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:

Trakt user_list urls can also come in a shorter format, like this: `https://trakt.tv/lists/24168047`. In the end, this is just a redirection (301) to the full url (`https://trakt.tv/users/openeyemedia/lists/animetvjay` in this example), but currently we only support the second one.

Short link is obtained from the Share Icon:
![Screenshot 2024-06-19 at 15 07 13](https://github.com/rivenmedia/riven/assets/5832671/3765b685-1bd4-44ab-81a8-aa4090bcb347)

This PR is meant to add support for both formats, like so:
```json
            "user_lists": [
                "https://trakt.tv/lists/24168047",
                "https://trakt.tv/users/openeyemedia/lists/animetvjay"
            ],
```