### PR TITLE
Add Zilean scraper: untested - Spoked can test :D

### DIFF
--- a/backend/program/scrapers/__init__.py
+++ b/backend/program/scrapers/__init__.py
@@ -13,6 +13,7 @@ from program.scrapers.orionoid import Orionoid
 from program.scrapers.prowlarr import Prowlarr
 from program.scrapers.torbox import TorBoxScraper
 from program.scrapers.torrentio import Torrentio
+from program.scrapers.zilean import Zilean
 from program.settings.manager import settings_manager
 from program.settings.versions import models
 from RTN import RTN, Torrent, sort_torrents
@@ -37,7 +38,8 @@ class Scraping:
             Jackett: Jackett(),
             TorBoxScraper: TorBoxScraper(),
             Mediafusion: Mediafusion(),
-            Prowlarr: Prowlarr()
+            Prowlarr: Prowlarr(),
+            Zilean: Zilean()
         }
         self.initialized = self.validate()
         if not self.initialized:

--- a/backend/program/scrapers/zilean.py
+++ b/backend/program/scrapers/zilean.py
@@ -1,0 +1,117 @@
+""" Zilean scraper module """
+
+from typing import Dict
+from program.media.item import Episode, MediaItem, Movie, Season, Show
+from program.settings.manager import settings_manager
+from program.settings.models import AppModel
+from requests import ConnectTimeout, ReadTimeout
+from requests.exceptions import RequestException
+from utils.logger import logger
+from utils.request import RateLimiter, RateLimitExceeded, post, ping
+
+
+class Zilean:
+    """Scraper for `Zilean`"""
+
+    def __init__(self):
+        self.key = "zilean"
+        self.api_key = None
+        self.downloader = None
+        self.app_settings: AppModel = settings_manager.settings
+        self.settings = self.app_settings.scraping.zilean
+        self.timeout = self.settings.timeout
+        self.initialized = self.validate()
+        if not self.initialized:
+            return
+        self.second_limiter = RateLimiter(max_calls=1, period=2) if self.settings.ratelimit else None
+        logger.success("Zilean initialized!")
+
+    def validate(self) -> bool:
+        """Validate the Zilean settings."""
+        if not self.settings.enabled:
+            logger.warning("Zilean is set to disabled.")
+            return False
+        if not self.settings.url:
+            logger.error("Zilean URL is not configured and will not be used.")
+            return False
+        if not isinstance(self.timeout, int) or self.timeout <= 0:
+            logger.error("Zilean timeout is not set or invalid.")
+            return False
+        if not isinstance(self.settings.ratelimit, bool):
+            logger.error("Zilean ratelimit must be a valid boolean.")
+            return False
+
+        try:
+            url = f"{self.settings.url}/healthchecks/ping"
+            response = ping(url=url, timeout=self.timeout)
+            return response.ok
+        except Exception as e:
+            logger.error(f"Zilean failed to initialize: {e}")
+            return False
+
+    def run(self, item: MediaItem) -> Dict[str, str]:
+        """Scrape the Zilean site for the given media items and update the object with scraped items"""
+        if not item or isinstance(item, Show):
+            return {}
+
+        try:
+            return self.scrape(item)
+        except RateLimitExceeded:
+            if self.second_limiter:
+                self.second_limiter.limit_hit()
+            else:
+                logger.warning(f"Zilean ratelimit exceeded for item: {item.log_string}")
+        except ConnectTimeout:
+            logger.warning(f"Zilean connection timeout for item: {item.log_string}")
+        except ReadTimeout:
+            logger.warning(f"Zilean read timeout for item: {item.log_string}")
+        except RequestException as e:
+            logger.error(f"Zilean request exception: {e}")
+        except Exception as e:
+            logger.error(f"Zilean exception thrown: {e}")
+        return {}
+
+    def scrape(self, item: MediaItem) -> Dict[str, str]:
+        """Scrape the given media item"""
+        data, item_count = self.api_scrape(item)
+        if data:
+            logger.log("SCRAPER", f"Found {len(data)} entries out of {item_count} for {item.log_string}")
+        else:
+            logger.log("NOT_FOUND", f"No entries found for {item.log_string}")
+        return data
+
+    def api_scrape(self, item: MediaItem) -> tuple[Dict[str, str], int]:
+        """Wrapper for `Zilean` scrape method"""
+        query_text = item.title if isinstance(item, (Movie, Season, Episode)) else ""
+        if not query_text:
+            return {}, 0
+
+        url = f"{self.settings.url}/dmm/search"
+        payload = {"queryText": query_text}
+
+        if self.second_limiter:
+            with self.second_limiter:
+                response = post(url, json=payload, timeout=self.timeout)
+        else:
+            response = post(url, json=payload, timeout=self.timeout)
+
+        if not response.ok:
+            return {}, 0
+
+        try:
+            data = response.json()
+        except ValueError:
+            logger.error("Zilean response is not valid JSON")
+            return {}, 0
+
+        torrents: Dict[str, str] = {}
+        
+        for result in data:
+            filename = result.get("filename")
+            infoHash = result.get("infoHash")
+            if not filename or not infoHash:
+                continue
+
+            torrents[infoHash] = filename
+
+        return torrents, len(data)

--- a/backend/program/settings/models.py
+++ b/backend/program/settings/models.py
@@ -152,6 +152,12 @@ class KnightcrawlerConfig(Observable):
     timeout: int = 30
     ratelimit: bool = True
 
+class ZileanConfig(Observable):
+    enabled: bool = False
+    url: str = "http://localhost:8181"
+    timeout: int = 30
+    ratelimit: bool = True
+
 
 class MediafusionConfig(Observable):
     enabled: bool = False
@@ -215,6 +221,7 @@ class ScraperModel(Observable):
     annatar: AnnatarConfig = AnnatarConfig()
     torbox_scraper: TorBoxScraperConfig = TorBoxScraperConfig()
     mediafusion: MediafusionConfig = MediafusionConfig()
+    zilean: ZileanConfig = ZileanConfig()
 
 
 # Version Ranking Model (set application defaults here!)

--- a/backend/program/types.py
+++ b/backend/program/types.py
@@ -13,12 +13,13 @@ from program.scrapers import (
     Orionoid,
     Scraping,
     Torrentio,
+    Zilean
 )
 from program.scrapers.torbox import TorBoxScraper
 from program.symlink import Symlinker
 
 # Typehint classes
-Scraper = Union[Scraping, Torrentio, Knightcrawler, Mediafusion, Orionoid, Jackett, Annatar, TorBoxScraper]
+Scraper = Union[Scraping, Torrentio, Knightcrawler, Mediafusion, Orionoid, Jackett, Annatar, TorBoxScraper, Zilean]
 Content = Union[Overseerr, PlexWatchlist, Listrr, Mdblist, TraktContent]
 Downloader = Union[Debrid, TorBoxDownloader]
 Service = Union[Content, SymlinkLibrary, Scraper, Downloader, Symlinker]


### PR DESCRIPTION
Zilean is a service that allows you to search for DebridMediaManager sourced arr-less content. When the service is started, it will automatically download and index all the DMM shared hashlists and index them using Lucene. The service provides a search endpoint that allows you to search for content using a query string, and returns a list of filenames and infohashes. There is no clean filtering applied to the search results, the idea behind this endpoint is Riven performs that using RTN. The DMM import reruns on missing pages every hour. Its written exclusively for Riven

https://github.com/iPromKnight/zilean
