### PR TITLE
Add releaseplease workflow for versioned releases (supports ElfHosted)

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,20 @@
+name: "Release Please"
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+


### PR DESCRIPTION
Hey!

This PR adds support for versioned releases based on [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/), using https://github.com/googleapis/release-please.

To use it to cut releases, just commit to main with `feat: <blah>` or `fix: <blah>`, and it'll open a PR to capture all your changes since the last release. When you're ready to release, just merge the PR.

You can make it start on a particular version number by including `"Release-As: 0.7.5"` in your commit **body** :)

You'll need a GH actions secret named `RELEASE_PLEASE_TOKEN`, containing a fine-grained token with the following permissions to this repo:

* Contents: Read/Write
* Metadata: Read (mandatory)
* Pull requests: Read/Write

Assuming this workflow is in place, ElfHosted can build off your latest **release** tag, instead of the latest main, which should make updates / releases more parsable :)