### PR TITLE
allow PUID/GUID other than 1000:1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,6 @@ RUN mkdir -p /usr/share/fonts/nerd-fonts && \
 # Install Poetry
 RUN pip install poetry==1.8.3
 
-# Create user and group
-RUN addgroup -g 1000 riven && \
-    adduser -u 1000 -G riven -h /home/riven -s /usr/bin/fish -D riven
-
 # Create fish config directory
 RUN mkdir -p /home/riven/.config/fish
 
@@ -81,9 +77,9 @@ ENV TERM=xterm-256color
 WORKDIR /riven
 
 # Copy frontend build from the previous stage
-COPY --from=frontend --chown=riven:riven /app/build /riven/frontend/build
-COPY --from=frontend --chown=riven:riven /app/node_modules /riven/frontend/node_modules
-COPY --from=frontend --chown=riven:riven /app/package.json /riven/frontend/package.json
+COPY --from=frontend  /app/build /riven/frontend/build
+COPY --from=frontend  /app/node_modules /riven/frontend/node_modules
+COPY --from=frontend  /app/package.json /riven/frontend/package.json
 
 # Copy the virtual environment from the builder stage
 COPY --from=builder /app/.venv /app/.venv
@@ -97,9 +93,6 @@ COPY VERSION entrypoint.sh /riven/
 
 # Ensure entrypoint script is executable
 RUN chmod +x /riven/entrypoint.sh
-
-# Set correct permissions for the riven user
-RUN chown -R riven:riven /home/riven/.config /riven
 
 # Switch to fish shell
 SHELL ["fish", "--login"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,6 @@ if [ "$PUID" = "0" ]
     echo running as root user
     set USER_HOME "/home/$USERNAME"
     mkdir -p $USER_HOME
-    chown -R $PUID:$PGID $USER_HOME
-    chown -R $PUID:$PGID /riven
 else
     if not echo $PUID | grep -qE '^[0-9]+$'
         echo "PUID is not a valid integer. Exiting..."
@@ -55,7 +53,7 @@ else
     set USER_HOME "/home/$USERNAME"
     mkdir -p $USER_HOME
     chown -R $PUID:$PGID $USER_HOME
-    chown -R $PUID:$PGID /riven
+    chown -R $PUID:$PGID /riven/data
 end
 
 umask 002

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,51 +4,59 @@ set PGID (set -q PGID; and echo $PGID; or echo 1000)
 
 echo "Starting Container with $PUID:$PGID permissions..."
 
-if not echo $PUID | grep -qE '^[0-9]+$'
-    echo "PUID is not a valid integer. Exiting..."
-    exit 1
-end
-
-if not echo $PGID | grep -qE '^[0-9]+$'
-    echo "PGID is not a valid integer. Exiting..."
-    exit 1
-end
-
-set -q USERNAME; or set USERNAME riven
-set -q GROUPNAME; or set GROUPNAME riven
-
-if not getent group $PGID > /dev/null
-    addgroup -g $PGID $GROUPNAME
-    if test $status -ne 0
-        echo "Failed to create group. Exiting..."
+if [ "$PUID" = "0" ] 
+    echo running as root user
+    set USER_HOME "/home/$USERNAME"
+    mkdir -p $USER_HOME
+    chown -R $PUID:$PGID $USER_HOME
+    chown -R $PUID:$PGID /riven
+else
+    if not echo $PUID | grep -qE '^[0-9]+$'
+        echo "PUID is not a valid integer. Exiting..."
         exit 1
     end
-else
-    set GROUPNAME (getent group $PGID | cut -d: -f1)
-end
-
-if not getent passwd $USERNAME > /dev/null
-    adduser -D -u $PUID -G $GROUPNAME $USERNAME
-    if test $status -ne 0
-        echo "Failed to create user. Exiting..."
+    
+    if not echo $PGID | grep -qE '^[0-9]+$'
+        echo "PGID is not a valid integer. Exiting..."
         exit 1
     end
-else
-    if test $PUID -ne 0
-        usermod -u $PUID -g $PGID $USERNAME
+    
+    set -q USERNAME; or set USERNAME riven
+    set -q GROUPNAME; or set GROUPNAME riven
+    
+    if not getent group $PGID > /dev/null
+        addgroup -g $PGID $GROUPNAME
         if test $status -ne 0
-            echo "Failed to modify user UID/GID. Exiting..."
-            exit 1
+    	echo "Failed to create group. Exiting..."
+    	exit 1
         end
     else
-        echo "Skipping usermod for root user."
+        set GROUPNAME (getent group $PGID | cut -d: -f1)
     end
+    
+    if not getent passwd $USERNAME > /dev/null
+        adduser -D -u $PUID -G $GROUPNAME $USERNAME
+        if test $status -ne 0
+    	echo "Failed to create user. Exiting..."
+    	exit 1
+        end
+    else
+        if test $PUID -ne 0
+    	usermod -u $PUID -g $PGID $USERNAME
+    	if test $status -ne 0
+    	    echo "Failed to modify user UID/GID. Exiting..."
+    	    exit 1
+    	end
+        else
+    	echo "Skipping usermod for root user."
+        end
+    end
+    
+    set USER_HOME "/home/$USERNAME"
+    mkdir -p $USER_HOME
+    chown -R $PUID:$PGID $USER_HOME
+    chown -R $PUID:$PGID /riven
 end
-
-set USER_HOME "/home/$USERNAME"
-mkdir -p $USER_HOME
-chown -R $PUID:$PGID $USER_HOME
-chown -R $PUID:$PGID /riven
 
 umask 002
 


### PR DESCRIPTION
## Description:

Fixes the issue where riven won't start if PUID and PGID are not set to 1000:1000

Dockerfile was adding the "riven" user with 1000:1000,  entrypoint.sh tried to add it again if PUID/PGID were set different.

Now entrypoint.sh is the only place that adds & chowns, with a special test for the root user (PUID 0)
