### PR TITLE
Main

### DIFF
--- a/backend/program/media/item.py
+++ b/backend/program/media/item.py
@@ -258,6 +258,10 @@ class Movie(MediaItem):
     def __hash__(self):
         return super().__hash__()
 
+    def fill_in_missing_children(self, other: Self):
+        # Since a movie typically does not have children, this method can be used to update missing attributes instead.
+        self.copy_other_media_attr(other)
+
 class Show(MediaItem):
     """Show class"""
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:

4-07-04 04:42:47 | ❌ ERROR     | main.<module> - Error in main thread: 'Movie' object has no attribute 'fill_in_missing_children'
24-07-04 04:42:47 | ❌ ERROR     | main.<module> - Traceback (most recent call last):
  File "/riven/backend/main.py", line 114, in <module>
    app.program.run()
  File "/riven/backend/program/program.py", line 379, in run
    updated_item, next_service, items_to_submit = process_event(
                                                  ^^^^^^^^^^^^^^
  File "/riven/backend/program/state_transition.py", line 37, in process_event
    existing_item.fill_in_missing_children(item)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Movie' object has no attribute 'fill_in_missing_children'

Traceback (most recent call last):
  File "/riven/backend/main.py", line 114, in <module>
    app.program.run()
  File "/riven/backend/program/program.py", line 379, in run
    updated_item, next_service, items_to_submit = process_event(
  File "/riven/backend/program/state_transition.py", line 37, in process_event
    existing_item.fill_in_missing_children(item)
AttributeError: 'Movie' object has no attribute 'fill_in_missing_children'
24-07-04 04:42:47 |  CRITICAL  | main.<module> - Server has been stopped

subsiquently the error after 


Error submitting job "Program._submit_job (trigger: interval[0:05:00], next run at: 2024-07-04 04:47:31 AEST)" to executor "default"
Traceback (most recent call last):
  File "/app/.venv/lib/python3.11/site-packages/apscheduler/schedulers/base.py", line 988, in _process_jobs
    executor.submit_job(job, run_times)
  File "/app/.venv/lib/python3.11/site-packages/apscheduler/executors/base.py", line 71, in submit_job
    self._do_submit_job(job, run_times)
  File "/app/.venv/lib/python3.11/site-packages/apscheduler/executors/pool.py", line 28, in _do_submit_job
    f = self._pool.submit(run_job, job, job._jobstore_alias, run_times, self._logger.name)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 167, in submit
    raise RuntimeError('cannot schedule new futures after shutdown')
RuntimeError: cannot schedule new futures after shutdown