### PR TITLE
Refactor Zilean scraper for MediaItem support

### DIFF
--- a/backend/program/scrapers/zilean.py
+++ b/backend/program/scrapers/zilean.py
@@ -93,8 +93,8 @@ class Zilean:
         url = f"{self.settings.url}/dmm/filtered"
         params = {"Query": title}
 
-        if isinstance(item, Movie) and hasattr(item, 'aired_at'):
-            params["Year"] = item.aired_at.year
+        if isinstance(item, MediaItem) and hasattr(item, 'year'):
+            params["Year"] = item.year
 
         if isinstance(item, Show):
             params["Season"] = 1


### PR DESCRIPTION
The Zilean scraper has been refactored to support the MediaItem class. Previously, it only supported the Movie class. The 'aired_at' attribute of a Movie instance is now replaced with the 'year' attribute of a MediaItem instance. This change allows more flexibility in handling different types of media items beyond just movies.

