### PR TITLE
fix: trakt indexer ignoring `Show`, `Season`, `Episode` items missing `country`

### DIFF
--- a/backend/program/indexers/trakt.py
+++ b/backend/program/indexers/trakt.py
@@ -118,8 +118,9 @@ def _map_item_from_data(data, item_type: str, show_genres: List[str] = None) -> 
     }
 
     item["is_anime"] = (
-        ("anime" in genres or "animation" in genres) if genres
-        and item["country"] in ("jp", "kr")
+        ("anime" in genres) 
+        or ("animation" in genres and (item["country"] in ("jp", "kr") or item["language"] == "ja"))
+        if genres
         else False
     )
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #539

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:

When indexing sometimes it gets anime shows and movies wrong. This PR fixes that

## Limitations

* May not correctly categorize non japanese anime. e.g. An animation tagged as somewhere else but having japanese production (language, production company, etc.) [Belle 2021](https://trakt.tv/movies/belle-2021)