### PR TITLE
fix: comet validation needed is_ok on response instead of ok

### DIFF
--- a/src/program/scrapers/comet.py
+++ b/src/program/scrapers/comet.py
@@ -53,7 +53,7 @@ class Comet:
         try:
             url = f"{self.settings.url}/manifest.json"
             response = ping(url=url, timeout=self.timeout)
-            if response.ok:
+            if response.is_ok:
                 return True
         except Exception as e:
             logger.error(f"Comet failed to initialize: {e}", )


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:

comet validation wasnt using the wrapped response attribute `is_ok` to check if the response received the 200 status