### PR TITLE
fix: optimize database operations and add indexing

### DIFF
--- a/src/program/db/db.py
+++ b/src/program/db/db.py
@@ -1,13 +1,27 @@
 import os
+from datetime import datetime
 
 from alembic.autogenerate import compare_metadata
 from alembic.runtime.migration import MigrationContext
+from sqlalchemy import text
+
 from program.settings.manager import settings_manager
 from sqla_wrapper import Alembic, SQLAlchemy
 from utils import data_dir_path
 from utils.logger import logger
 
-db = SQLAlchemy(settings_manager.settings.database.host)
+engine_options={
+    "echo": False, # Prom: Set to true when debugging sql queries
+}
+
+# Prom: This is a good place to set the statement timeout for the database when debugging.
+# @event.listens_for(Engine, "connect")
+# def set_statement_timeout(dbapi_connection, connection_record):
+#     cursor = dbapi_connection.cursor()
+#     cursor.execute("SET statement_timeout = 300000")
+#     cursor.close()
+
+db = SQLAlchemy(settings_manager.settings.database.host, engine_options=engine_options)
 
 script_location = data_dir_path / "alembic/"
 
@@ -27,18 +41,39 @@ def need_upgrade_check() -> bool:
         diff = compare_metadata(mc, db.Model.metadata)
     return bool(diff)
 
+def ensure_alembic_version_table():
+    """Create alembic_version table if it doesn't exist."""
+    with db.engine.connect() as connection:
+        result = connection.execute(text("SELECT table_name FROM information_schema.tables WHERE table_name = 'alembic_version'"))
+        if not result.fetchone():
+            logger.debug("alembic_version table not found. Creating it...")
+            alembic.stamp('head')
+            logger.debug("alembic_version table created and stamped to head.")
 
-def run_migrations() -> None:
-    """Run Alembic migrations if needed."""
+def vacuum_and_analyze_index_maintenance() -> None:
+    # PROM: Use the raw connection to execute VACUUM outside a transaction
     try:
-        if need_upgrade_check():
-            logger.info("New migrations detected, creating revision...")
-            alembic.revision("auto-upg")
-            logger.info("Applying migrations...")
-            alembic.upgrade()
-        else:
-            logger.info("No new migrations detected.")
+        with db.engine.connect() as connection:
+            connection = connection.execution_options(isolation_level="AUTOCOMMIT")
+            connection.execute(text("VACUUM;"))
+            connection.execute(text("ANALYZE;"))
+        logger.info("VACUUM and ANALYZE completed successfully.")
     except Exception as e:
-        logger.error(f"Error during migration: {e}")
-        logger.info("Attempting to apply existing migrations...")
-        alembic.upgrade()
+        logger.error(f"Error during VACUUM and ANALYZE: {e}")
+
+def run_migrations(try_again=True) -> None:
+    try:
+        ensure_alembic_version_table()
+        if need_upgrade_check():
+            timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+            alembic.revision(f"auto-upg {timestamp}")
+            alembic.upgrade()
+    except Exception as e:
+        logger.warning(f"Error running migrations: {e}")
+        db.s.execute(text("delete from alembic_version"))
+        db.s.commit()
+        alembic.stamp('head')
+        if try_again:
+            run_migrations(False)
+        else:
+            exit(1)

--- a/src/program/db/db_functions.py
+++ b/src/program/db/db_functions.py
@@ -6,13 +6,42 @@ import alembic
 from program.media.item import Episode, MediaItem, Movie, Season, Show
 from program.media.stream import Stream, StreamRelation
 from program.types import Event
-from sqlalchemy import delete, func, select, text
-from sqlalchemy.orm import joinedload
+from sqlalchemy import delete, func, select, text, union_all
+from sqlalchemy.orm import joinedload, aliased
 from utils.logger import logger
 from utils import alembic_dir
 
 from .db import db, alembic
 
+def _get_item_ids(session, item):
+    if item.type == "show":
+        show_id = item._id
+
+        season_alias = aliased(Season, flat=True)
+        season_query = select(Season._id.label('id')).where(Season.parent_id == show_id)
+        episode_query = (
+            select(Episode._id.label('id'))
+            .join(season_alias, Episode.parent_id == season_alias._id)
+            .where(season_alias.parent_id == show_id)
+        )
+
+        combined_query = union_all(season_query, episode_query)
+        related_ids = session.execute(combined_query).scalars().all()
+        return show_id, related_ids
+
+    elif item.type == "season":
+        season_id = item._id
+        episode_ids = session.execute(
+            select(Episode._id)
+            .where(Episode.parent_id == season_id)
+        ).scalars().all()
+        return season_id, episode_ids
+
+    elif hasattr(item, "parent"):
+        parent_id = item.parent._id
+        return parent_id, []
+
+    return item._id, []
 
 def _ensure_item_exists_in_db(item: MediaItem) -> bool:
     if isinstance(item, (Movie, Show)):

--- a/src/program/media/item.py
+++ b/src/program/media/item.py
@@ -6,6 +6,8 @@ from typing import List, Optional, Self
 import asyncio
 
 import sqlalchemy
+from sqlalchemy import Index
+
 from program.db.db import db
 from program.media.state import States
 from RTN import parse
@@ -63,7 +65,27 @@ class MediaItem(db.Model):
         "polymorphic_on":"type",
         "with_polymorphic":"*",
     }
-    def __init__(self, item: dict) -> None:
+
+    __table_args__ = (
+        Index('ix_mediaitem_item_id', 'item_id'),
+        Index('ix_mediaitem_type', 'type'),
+        Index('ix_mediaitem_requested_by', 'requested_by'),
+        Index('ix_mediaitem_title', 'title'),
+        Index('ix_mediaitem_imdb_id', 'imdb_id'),
+        Index('ix_mediaitem_tvdb_id', 'tvdb_id'),
+        Index('ix_mediaitem_tmdb_id', 'tmdb_id'),
+        Index('ix_mediaitem_network', 'network'),
+        Index('ix_mediaitem_country', 'country'),
+        Index('ix_mediaitem_language', 'language'),
+        Index('ix_mediaitem_aired_at', 'aired_at'),
+        Index('ix_mediaitem_year', 'year'),
+        Index('ix_mediaitem_overseerr_id', 'overseerr_id'),
+        Index('ix_mediaitem_type_aired_at', 'type', 'aired_at'),  # Composite index
+    )
+    
+    def __init__(self, item: dict | None) -> None:
+        if item is None:
+            return
         self.requested_at = item.get("requested_at", datetime.now())
         self.requested_by = item.get("requested_by")
 

--- a/src/program/media/stream.py
+++ b/src/program/media/stream.py
@@ -1,4 +1,6 @@
 from RTN import Torrent
+from sqlalchemy import Index
+
 from program.db.db import db
 import sqlalchemy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -10,6 +12,11 @@ class StreamRelation(db.Model):
     _id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     parent_id: Mapped[int] = mapped_column(sqlalchemy.Integer, sqlalchemy.ForeignKey("MediaItem._id", ondelete="CASCADE"))
     child_id: Mapped[int] = mapped_column(sqlalchemy.Integer, sqlalchemy.ForeignKey("Stream._id", ondelete="CASCADE"))
+
+    __table_args__ = (
+        Index('ix_streamrelation_parent_id', 'parent_id'),
+        Index('ix_streamrelation_child_id', 'child_id'),
+    )
     
 class StreamBlacklistRelation(db.Model):
     __tablename__ = "StreamBlacklistRelation"
@@ -17,6 +24,11 @@ class StreamBlacklistRelation(db.Model):
     _id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     media_item_id: Mapped[int] = mapped_column(sqlalchemy.Integer, sqlalchemy.ForeignKey("MediaItem._id", ondelete="CASCADE"))
     stream_id: Mapped[int] = mapped_column(sqlalchemy.Integer, sqlalchemy.ForeignKey("Stream._id", ondelete="CASCADE"))
+
+    __table_args__ = (
+        Index('ix_streamblacklistrelation_media_item_id', 'media_item_id'),
+        Index('ix_streamblacklistrelation_stream_id', 'stream_id'),
+    )
 
 class Stream(db.Model):
     __tablename__ = "Stream"
@@ -30,6 +42,13 @@ class Stream(db.Model):
 
     parents: Mapped[list["MediaItem"]] = relationship(secondary="StreamRelation", back_populates="streams")
     blacklisted_parents: Mapped[list["MediaItem"]] = relationship(secondary="StreamBlacklistRelation", back_populates="blacklisted_streams")
+
+    __table_args__ = (
+        Index('ix_stream_infohash', 'infohash'),
+        Index('ix_stream_raw_title', 'raw_title'),
+        Index('ix_stream_parsed_title', 'parsed_title'),
+        Index('ix_stream_rank', 'rank'),
+    )
 
     def __init__(self, torrent: Torrent):
         self.raw_title = torrent.raw_title

--- a/src/program/media/subtitle.py
+++ b/src/program/media/subtitle.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from program.db.db import db
-from sqlalchemy import Integer, String, ForeignKey
+from sqlalchemy import Integer, String, ForeignKey, Index
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 
@@ -13,6 +13,12 @@ class Subtitle(db.Model):
     
     parent_id: Mapped[int] = mapped_column(Integer, ForeignKey("MediaItem._id", ondelete="CASCADE"))
     parent: Mapped["MediaItem"] = relationship("MediaItem", back_populates="subtitles")
+
+    __table_args__ = (
+        Index('ix_subtitle_language', 'language'),
+        Index('ix_subtitle_file', 'file'),
+        Index('ix_subtitle_parent_id', 'parent_id'),
+    )
    
     def __init__(self, optional={}):
         for key in optional.keys():


### PR DESCRIPTION
- Introduced `_get_item_ids` function to retrieve related item IDs for shows and seasons.
- Added multiple indexes to `Stream`, `StreamRelation`, `StreamBlacklistRelation`, `MediaItem`, and `Subtitle` tables to improve query performance.
- Enhanced `run_migrations` to ensure `alembic_version` table exists and handle errors more gracefully.
- Added `vacuum_and_analyze_index_maintenance` function for regular database maintenance.
- Refactored `_retry_library` to optimize item retrieval and processing.
- Updated `_add_event_to_queue` to use `_get_item_ids` for checking related items in the queue.
- Minor improvements and bug fixes in database session handling and logging.

