### PR TITLE
feat: add indexing and maintenance functions to database operations

### DIFF
--- a/src/program/db/db.py
+++ b/src/program/db/db.py
@@ -1,16 +1,25 @@
 import os
+from datetime import datetime
 
 from alembic.autogenerate import compare_metadata
 from alembic.runtime.migration import MigrationContext
+from sqlalchemy import text
+
 from program.settings.manager import settings_manager
 from sqla_wrapper import Alembic, SQLAlchemy
 from utils import data_dir_path
 from utils.logger import logger
 
 engine_options={
-    "pool_size": 50,
-    "pool_recycle": 600,
+    "echo": False, # Prom: Set to true when debugging sql queries
 }
+
+# Prom: This is a good place to set the statement timeout for the database when debugging.
+# @event.listens_for(Engine, "connect")
+# def set_statement_timeout(dbapi_connection, connection_record):
+#     cursor = dbapi_connection.cursor()
+#     cursor.execute("SET statement_timeout = 300000")
+#     cursor.close()
 
 db = SQLAlchemy(settings_manager.settings.database.host, engine_options=engine_options)
 
@@ -32,18 +41,39 @@ def need_upgrade_check() -> bool:
         diff = compare_metadata(mc, db.Model.metadata)
     return bool(diff)
 
+def ensure_alembic_version_table():
+    """Create alembic_version table if it doesn't exist."""
+    with db.engine.connect() as connection:
+        result = connection.execute(text("SELECT table_name FROM information_schema.tables WHERE table_name = 'alembic_version'"))
+        if not result.fetchone():
+            logger.debug("alembic_version table not found. Creating it...")
+            alembic.stamp('head')
+            logger.debug("alembic_version table created and stamped to head.")
 
-def run_migrations() -> None:
-    """Run Alembic migrations if needed."""
+def vacuum_and_analyze_index_maintenance() -> None:
+    # PROM: Use the raw connection to execute VACUUM outside a transaction
     try:
-        if need_upgrade_check():
-            logger.info("New migrations detected, creating revision...")
-            alembic.revision("auto-upg")
-            logger.info("Applying migrations...")
-            alembic.upgrade()
-        else:
-            logger.info("No new migrations detected.")
+        with db.engine.connect() as connection:
+            connection = connection.execution_options(isolation_level="AUTOCOMMIT")
+            connection.execute(text("VACUUM;"))
+            connection.execute(text("ANALYZE;"))
+        logger.info("VACUUM and ANALYZE completed successfully.")
     except Exception as e:
-        logger.error(f"Error during migration: {e}")
-        logger.info("Attempting to apply existing migrations...")
-        alembic.upgrade()
+        logger.error(f"Error during VACUUM and ANALYZE: {e}")
+
+def run_migrations(try_again=True) -> None:
+    try:
+        ensure_alembic_version_table()
+        if need_upgrade_check():
+            timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+            alembic.revision(f"auto-upg {timestamp}")
+            alembic.upgrade()
+    except Exception as e:
+        logger.warning(f"Error running migrations: {e}")
+        db.s.execute(text("delete from alembic_version"))
+        db.s.commit()
+        alembic.stamp('head')
+        if try_again:
+            run_migrations(False)
+        else:
+            exit(1)

--- a/src/program/db/db_functions.py
+++ b/src/program/db/db_functions.py
@@ -6,8 +6,8 @@ import alembic
 from program.media.item import Episode, MediaItem, Movie, Season, Show
 from program.media.stream import Stream, StreamRelation
 from program.types import Event
-from sqlalchemy import delete, func, select, text
-from sqlalchemy.orm import joinedload
+from sqlalchemy import delete, func, select, text, union_all
+from sqlalchemy.orm import joinedload, aliased
 from utils.logger import logger
 from utils import alembic_dir
 from program.libraries.symlink import fix_broken_symlinks
@@ -15,6 +15,35 @@ from program.settings.manager import settings_manager
 
 from .db import db, alembic
 
+def _get_item_ids(session, item):
+    if item.type == "show":
+        show_id = item._id
+
+        season_alias = aliased(Season, flat=True)
+        season_query = select(Season._id.label('id')).where(Season.parent_id == show_id)
+        episode_query = (
+            select(Episode._id.label('id'))
+            .join(season_alias, Episode.parent_id == season_alias._id)
+            .where(season_alias.parent_id == show_id)
+        )
+
+        combined_query = union_all(season_query, episode_query)
+        related_ids = session.execute(combined_query).scalars().all()
+        return show_id, related_ids
+
+    elif item.type == "season":
+        season_id = item._id
+        episode_ids = session.execute(
+            select(Episode._id)
+            .where(Episode.parent_id == season_id)
+        ).scalars().all()
+        return season_id, episode_ids
+
+    elif hasattr(item, "parent"):
+        parent_id = item.parent._id
+        return parent_id, []
+
+    return item._id, []
 
 def _ensure_item_exists_in_db(item: MediaItem) -> bool:
     if isinstance(item, (Movie, Show)):

--- a/src/program/media/item.py
+++ b/src/program/media/item.py
@@ -7,6 +7,8 @@ import asyncio
 from sqla_wrapper import Session
 
 import sqlalchemy
+from sqlalchemy import Index
+
 from program.db.db import db
 from program.media.state import States
 from RTN import parse
@@ -64,7 +66,27 @@ class MediaItem(db.Model):
         "polymorphic_on":"type",
         "with_polymorphic":"*",
     }
-    def __init__(self, item: dict) -> None:
+
+    __table_args__ = (
+        Index('ix_mediaitem_item_id', 'item_id'),
+        Index('ix_mediaitem_type', 'type'),
+        Index('ix_mediaitem_requested_by', 'requested_by'),
+        Index('ix_mediaitem_title', 'title'),
+        Index('ix_mediaitem_imdb_id', 'imdb_id'),
+        Index('ix_mediaitem_tvdb_id', 'tvdb_id'),
+        Index('ix_mediaitem_tmdb_id', 'tmdb_id'),
+        Index('ix_mediaitem_network', 'network'),
+        Index('ix_mediaitem_country', 'country'),
+        Index('ix_mediaitem_language', 'language'),
+        Index('ix_mediaitem_aired_at', 'aired_at'),
+        Index('ix_mediaitem_year', 'year'),
+        Index('ix_mediaitem_overseerr_id', 'overseerr_id'),
+        Index('ix_mediaitem_type_aired_at', 'type', 'aired_at'),  # Composite index
+    )
+    
+    def __init__(self, item: dict | None) -> None:
+        if item is None:
+            return
         self.requested_at = item.get("requested_at", datetime.now())
         self.requested_by = item.get("requested_by")
 

--- a/src/program/media/stream.py
+++ b/src/program/media/stream.py
@@ -1,4 +1,6 @@
 from RTN import Torrent
+from sqlalchemy import Index
+
 from program.db.db import db
 import sqlalchemy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -10,6 +12,11 @@ class StreamRelation(db.Model):
     _id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     parent_id: Mapped[int] = mapped_column(sqlalchemy.Integer, sqlalchemy.ForeignKey("MediaItem._id", ondelete="CASCADE"))
     child_id: Mapped[int] = mapped_column(sqlalchemy.Integer, sqlalchemy.ForeignKey("Stream._id", ondelete="CASCADE"))
+
+    __table_args__ = (
+        Index('ix_streamrelation_parent_id', 'parent_id'),
+        Index('ix_streamrelation_child_id', 'child_id'),
+    )
     
 class StreamBlacklistRelation(db.Model):
     __tablename__ = "StreamBlacklistRelation"
@@ -17,6 +24,11 @@ class StreamBlacklistRelation(db.Model):
     _id: Mapped[int] = mapped_column(sqlalchemy.Integer, primary_key=True)
     media_item_id: Mapped[int] = mapped_column(sqlalchemy.Integer, sqlalchemy.ForeignKey("MediaItem._id", ondelete="CASCADE"))
     stream_id: Mapped[int] = mapped_column(sqlalchemy.Integer, sqlalchemy.ForeignKey("Stream._id", ondelete="CASCADE"))
+
+    __table_args__ = (
+        Index('ix_streamblacklistrelation_media_item_id', 'media_item_id'),
+        Index('ix_streamblacklistrelation_stream_id', 'stream_id'),
+    )
 
 class Stream(db.Model):
     __tablename__ = "Stream"
@@ -30,6 +42,13 @@ class Stream(db.Model):
 
     parents: Mapped[list["MediaItem"]] = relationship(secondary="StreamRelation", back_populates="streams")
     blacklisted_parents: Mapped[list["MediaItem"]] = relationship(secondary="StreamBlacklistRelation", back_populates="blacklisted_streams")
+
+    __table_args__ = (
+        Index('ix_stream_infohash', 'infohash'),
+        Index('ix_stream_raw_title', 'raw_title'),
+        Index('ix_stream_parsed_title', 'parsed_title'),
+        Index('ix_stream_rank', 'rank'),
+    )
 
     def __init__(self, torrent: Torrent):
         self.raw_title = torrent.raw_title

--- a/src/program/media/subtitle.py
+++ b/src/program/media/subtitle.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from program.db.db import db
-from sqlalchemy import Integer, String, ForeignKey
+from sqlalchemy import Integer, String, ForeignKey, Index
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 
@@ -13,6 +13,12 @@ class Subtitle(db.Model):
     
     parent_id: Mapped[int] = mapped_column(Integer, ForeignKey("MediaItem._id", ondelete="CASCADE"))
     parent: Mapped["MediaItem"] = relationship("MediaItem", back_populates="subtitles")
+
+    __table_args__ = (
+        Index('ix_subtitle_language', 'language'),
+        Index('ix_subtitle_file', 'file'),
+        Index('ix_subtitle_parent_id', 'parent_id'),
+    )
    
     def __init__(self, optional={}):
         for key in optional.keys():

--- a/src/program/post_processing/subliminal.py
+++ b/src/program/post_processing/subliminal.py
@@ -11,6 +11,8 @@ class Subliminal:
     def __init__(self):
         self.key = "subliminal"
         self.settings = settings_manager.settings.post_processing.subliminal
+        if not self.settings.enabled:
+            return
         providers = ['gestdown','opensubtitles','opensubtitlescom','podnapisi','tvsubtitles']
         provider_config = {}
         for provider in self.settings.providers.keys():
@@ -128,4 +130,3 @@ def get_existing_subtitles(filename: str, path: pathlib.Path) -> set[Language]:
                     language.file = file.name
                     subtitle_languages.add(language)
     return subtitle_languages
-

--- a/src/program/program.py
+++ b/src/program/program.py
@@ -41,7 +41,7 @@ if settings_manager.settings.tracemalloc:
 from sqlalchemy import func, select
 
 import program.db.db_functions as DB
-from program.db.db import db, run_migrations
+from program.db.db import db, run_migrations, vacuum_and_analyze_index_maintenance
 from sqlalchemy import func, select, text
 
 
@@ -207,23 +207,37 @@ class Program(threading.Thread):
         for page_number in range(0, (count // number_of_rows_per_page) + 1):
             with db.Session() as session:
                 items_to_submit = session.execute(
-                    select(MediaItem)
+                    select(
+                        MediaItem._id,
+                        MediaItem.type,
+                        MediaItem.last_state,
+                        MediaItem.requested_at,
+                        MediaItem.imdb_id
+                    )
                     .where(MediaItem.type.in_(["movie", "show"]))
                     .where(MediaItem.last_state != "Completed")
                     .order_by(MediaItem.requested_at.desc())
                     .limit(number_of_rows_per_page)
                     .offset(page_number * number_of_rows_per_page)
-                ).unique().scalars().all()
-
-                session.expunge(items_to_submit)
+                ).all()
+        
+                session.expunge_all()
                 session.close()
-                for item in items_to_submit:
+        
+                for item_data in items_to_submit:
+                    item = MediaItem(None)
+                    item._id = item_data[0]
+                    item.type = item_data[1]
+                    item.last_state = item_data[2]
+                    item.requested_at = item_data[3]
+                    item.imdb_id = item_data[4]
                     self.em.add_event(Event(emitted_by="RetryLibrary", item=item))
 
     def _schedule_functions(self) -> None:
         """Schedule each service based on its update interval."""
         scheduled_functions = {
             self._retry_library: {"interval": 60 * 10},
+            vacuum_and_analyze_index_maintenance: {"interval": 60 * 60 * 24},
         }
 
         if settings_manager.settings.symlink.repair_symlinks:

--- a/src/utils/event_manager.py
+++ b/src/utils/event_manager.py
@@ -6,7 +6,9 @@ from threading import Lock
 import time
 import traceback
 from subliminal import Episode, Movie
-from program.db.db_functions import _run_thread_with_db_item
+
+from program.db.db import db
+from program.db.db_functions import _run_thread_with_db_item, _get_item_ids
 from loguru import logger
 import utils.websockets.manager as ws_manager
 
@@ -236,30 +238,13 @@ class EventManager:
             logger.debug(f"Item {event.item.log_string} is already running, skipping.")
             return False
         # Check if the event's item is a show and its seasons or episodes are in the queue or running
-        elif event.item.type == "show":
-            for s in event.item.seasons:
-                if self._id_in_queue(s._id) or self._id_in_running_events(s._id):
-                    logger.debug(f"A season for {event.item.log_string} is already in the queue or running, skipping.")
-                    return False
-                for e in s.episodes:
-                    if self._id_in_queue(e._id) or self._id_in_running_events(e._id):
-                        logger.debug(f"An episode {event.item.log_string} is already in the queue or running, skipping.")
-                        return False
-        # Check if the event's item is a season and its episodes are in the queue or running
-        elif event.item.type == "season":
-            for e in event.item.episodes:
-                if self._id_in_queue(e._id) or self._id_in_running_events(e._id):
-                    logger.debug(f"An episode {event.item.log_string} is already in the queue or running, skipping.")
-                    return False
-        # Check if the event's item's parent or parent's parent is in the queue or running
-        elif hasattr(event.item, "parent"):
-            parent = event.item.parent
-            if self._id_in_queue(parent._id) or self._id_in_running_events(parent._id):
-                logger.debug(f"Parent {parent.log_string} is already in the queue or running, skipping.")
+        with db.Session() as session:
+            item_id, related_ids = _get_item_ids(session, event.item)
+            if self._id_in_queue(item_id) or self._id_in_running_events(item_id):
                 return False
-            elif hasattr(parent, "parent") and (self._id_in_queue(parent.parent._id) or self._id_in_running_events(parent.parent._id)):
-                logger.debug(f"Parent's parent {parent.parent.log_string} is already in the queue or running, skipping.")
-                return False
+            for related_id in related_ids:
+                if self._id_in_queue(related_id) or self._id_in_running_events(related_id):
+                    return False
 
         # Log the addition of the event to the queue
         if not isinstance(event.item, (Show, Movie, Episode, Season)):


### PR DESCRIPTION
- Introduced `_get_item_ids` function to retrieve related item IDs for shows and seasons.
- Added `ensure_alembic_version_table` and `vacuum_and_analyze_index_maintenance` functions for database maintenance.
- Implemented new indexes for `StreamRelation`, `StreamBlacklistRelation`, `Stream`, `MediaItem`, and `Subtitle` tables to improve query performance.
- Updated `_run_thread_with_db_item` to handle item insertion and retrieval more efficiently.
- Modified event manager to use `_get_item_ids` for checking related items in the queue.
- Scheduled `vacuum_and_analyze_index_maintenance` to run daily.
- Enhanced `run_migrations` to handle alembic version table creation and error recovery.
- Added conditional check for enabling subliminal settings in post-processing.
