### PR TITLE
feat: Add memray attachment script and update stream handling in downloaders

### DIFF
--- a/dev/attach-memray.sh
+++ b/dev/attach-memray.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Attach memray to the running main.py process
+# Usage: ./attach-memray.sh
+
+pgrep -f "main.py" | head -n 2 | xargs -I{} memray attach {}

--- a/src/program/db/db_functions.py
+++ b/src/program/db/db_functions.py
@@ -24,12 +24,10 @@ def reset_streams(media_item_id: int, active_stream_hash: str = None):
             if stream:
                 blacklist_stream(media_item_id, stream._id, session)
 
-        # Remove all associated streams
         session.execute(
             delete(StreamRelation).where(StreamRelation.parent_id == media_item_id)
         )
 
-        # Optionally, clear the blacklisted streams (if you want to reset those too)
         session.execute(
             delete(StreamBlacklistRelation).where(StreamBlacklistRelation.media_item_id == media_item_id)
         )

--- a/src/program/downloaders/__init__.py
+++ b/src/program/downloaders/__init__.py
@@ -4,6 +4,7 @@ from utils.logger import logger
 from .alldebrid import AllDebridDownloader
 from .realdebrid import RealDebridDownloader
 from .torbox import TorBoxDownloader
+from ..media import States
 
 
 class Downloader:

--- a/src/program/downloaders/alldebrid.py
+++ b/src/program/downloaders/alldebrid.py
@@ -166,7 +166,6 @@ class AllDebridDownloader:
     
                     filtered_streams = [infohash for infohash in stream_hashes.keys() if infohash and infohash not in processed_stream_hashes]
                     if not filtered_streams:
-                        logger.log("NOT_FOUND", f"No streams found from filtering: {item.log_string}")
                         return False
     
                     try:


### PR DESCRIPTION
- Introduced `attach-memray.sh` script to attach memray to the running `main.py` process.
- Updated `realdebrid.py` to increase the number of rows per page to 10 and use `blacklist_stream` function.
- Removed redundant log message in `alldebrid.py`.
- Imported `States` in `downloaders/__init__.py`.
- Minor refactoring in `db_functions.py` for consistency.
