### PR TITLE
refactor: Refactor `blacklist_stream` and `reset_streams` functions to use `MediaItem` object

### DIFF
--- a/dev/attach-memray.sh
+++ b/dev/attach-memray.sh
@@ -2,4 +2,4 @@
 # Attach memray to the running main.py process
 # Usage: ./attach-memray.sh
 
-pgrep -f "main.py" | head -n 2 | xargs -I{} memray attach {}
+pgrep -f "main.py" | head -n 1 | xargs -I{} memray attach {}

--- a/src/program/downloaders/realdebrid.py
+++ b/src/program/downloaders/realdebrid.py
@@ -209,7 +209,7 @@ class RealDebridDownloader:
                 continue
     
             if not provider_list or not provider_list.get("rd"):
-                if blacklist_stream(item._id, stream):
+                if item.blacklist_stream(stream):
                     logger.debug(f"Blacklisted un-cached stream for {item.log_string} with hash: {stream_hash}")
                 continue
     

--- a/src/program/media/item.py
+++ b/src/program/media/item.py
@@ -144,7 +144,7 @@ class MediaItem(db.Model):
         return stream in self.blacklisted_streams
 
     def blacklist_stream(self, stream: Stream):
-        return blacklist_stream(self._id, stream)
+        return blacklist_stream(self, stream)
 
     @property
     def is_released(self) -> bool:


### PR DESCRIPTION
- Updated `reset_streams` and `blacklist_stream` functions in `db_functions.py` to accept `MediaItem` object instead of `media_item_id`.
- Modified `realdebrid.py` and `item.py` to reflect changes in `blacklist_stream` function signature.
- Fixed `attach-memray.sh` script to attach memray to the first `main.py` process.
