### PR TITLE
fix: Ensure MediaItem is merged into session before operations in db_functions.py

### DIFF
--- a/src/program/db/db_functions.py
+++ b/src/program/db/db_functions.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 def reset_streams(item: "MediaItem", active_stream_hash: str = None):
     """Reset streams associated with a MediaItem."""
     with db.Session() as session:
+        item = session.merge(item)
         if active_stream_hash:
             stream = session.query(Stream).filter(Stream.infohash == active_stream_hash).first()
             if stream:
@@ -32,6 +33,7 @@ def reset_streams(item: "MediaItem", active_stream_hash: str = None):
             delete(StreamBlacklistRelation).where(StreamBlacklistRelation.media_item_id == item._id)
         )
         session.commit()
+        session.refresh(item)
 
 def blacklist_stream(item: "MediaItem", stream: Stream, session: Session = None) -> bool:
     """Blacklist a stream for a media item."""
@@ -41,6 +43,7 @@ def blacklist_stream(item: "MediaItem", stream: Stream, session: Session = None)
         close_session = True
 
     try:
+        item = session.merge(item)
         association_exists = session.query(
             session.query(StreamRelation)
             .filter(StreamRelation.parent_id == item._id)
@@ -61,6 +64,7 @@ def blacklist_stream(item: "MediaItem", stream: Stream, session: Session = None)
 
             if close_session:
                 session.commit()
+                session.refresh(item)
             return True
         return False
 

--- a/src/program/downloaders/realdebrid.py
+++ b/src/program/downloaders/realdebrid.py
@@ -148,7 +148,7 @@ class RealDebridDownloader:
         for page_number in range(total_pages):
             with db.Session() as session:
                 for stream_id, infohash, stream in load_streams_in_pages(session, item._id, page_number, page_size=number_of_rows_per_page):
-                    stream_hashes[infohash] = stream  # Store the Stream object
+                    stream_hashes[infohash.lower()] = stream
     
                     filtered_streams = [
                         infohash for infohash in stream_hashes.keys()

--- a/src/program/media/item.py
+++ b/src/program/media/item.py
@@ -3,9 +3,6 @@ from datetime import datetime
 import json
 from pathlib import Path
 from typing import List, Optional, Self
-import asyncio
-from sqla_wrapper import Session
-
 import sqlalchemy
 from sqlalchemy import Index
 


### PR DESCRIPTION
- Added session.merge(item) to ensure MediaItem is merged into the session before performing operations in `reset_streams` and `blacklist_stream`.
- Updated `stream_hashes` to store lowercase infohash keys in realdebrid.py.
- Removed unused imports in item.py.
