### PR TITLE
fix: Fix `reset_streams` function call and ensure `active_stream` is reset

### DIFF
--- a/src/program/db/db_functions.py
+++ b/src/program/db/db_functions.py
@@ -32,6 +32,7 @@ def reset_streams(item: "MediaItem", active_stream_hash: str = None):
         session.execute(
             delete(StreamBlacklistRelation).where(StreamBlacklistRelation.media_item_id == item._id)
         )
+        item.active_stream = None
         session.commit()
         session.refresh(item)
 

--- a/src/program/media/item.py
+++ b/src/program/media/item.py
@@ -335,7 +335,7 @@ class MediaItem(db.Model):
         self.set("alternative_folder", None)
 
         active_stream_hash = self.active_stream.get("hash", None)
-        reset_streams(self._id, active_stream_hash)
+        reset_streams(self, active_stream_hash)
 
         self.set("active_stream", {})
         self.set("symlinked", False)


### PR DESCRIPTION
- Corrected the `reset_streams` function call to pass the `MediaItem` object instead of its ID.
- Added a line to reset the `active_stream` attribute to `None` in the `reset_streams` function.
- Ensured the script exits after performing hard reset or symlink repair based on environment variables.
