### PR TITLE
feat: Add functions to delete MediaItems and associated relationships

### DIFF
--- a/src/program/db/db_functions.py
+++ b/src/program/db/db_functions.py
@@ -16,6 +16,47 @@ from .db import db, alembic
 if TYPE_CHECKING:
     from program.media.item import MediaItem
 
+def delete_media_item(item: "MediaItem"):
+    """Delete a MediaItem and all its associated relationships."""
+    with db.Session() as session:
+        item = session.merge(item)
+        session.delete(item)
+        session.commit()
+
+def delete_media_item_by_id(media_item_id: int):
+    """Delete a MediaItem and all its associated relationships by the MediaItem _id."""
+    from program.media.item import MediaItem
+    with db.Session() as session:
+        item = session.query(MediaItem).filter_by(_id=media_item_id).first()
+
+        if item:
+            session.delete(item)
+            session.commit()
+        else:
+            raise ValueError(f"MediaItem with id {media_item_id} does not exist.")
+
+def delete_media_item_by_item_id(item_id: str):
+    """Delete a MediaItem and all its associated relationships by the MediaItem _id."""
+    from program.media.item import MediaItem
+    with db.Session() as session:
+        item = session.query(MediaItem).filter_by(item_id=item_id).first()
+
+        if item:
+            session.delete(item)
+            session.commit()
+        else:
+            raise ValueError(f"MediaItem with item_id {item_id} does not exist.")
+
+def delete_media_items_by_ids(media_item_ids: list[int]):
+    """Delete multiple MediaItems and all their associated relationships by a list of MediaItem _ids."""
+    try:
+        for media_item_id in media_item_ids:
+            delete_media_item_by_id(media_item_id)
+    except Exception as e:
+        error = f"Failed to delete media items: {e}"
+        logger.error(error)
+        raise ValueError(error)
+
 def reset_streams(item: "MediaItem", active_stream_hash: str = None):
     """Reset streams associated with a MediaItem."""
     with db.Session() as session:

--- a/src/tests/test_db_functions.py
+++ b/src/tests/test_db_functions.py
@@ -4,9 +4,10 @@ from RTN import Torrent, ParsedData
 from testcontainers.postgres import PostgresContainer
 
 from program.db.db import db, run_migrations
-from program import MediaItem
+from program.media.item import MediaItem, Show, Season, Episode
 from program.media.stream import Stream, StreamRelation, StreamBlacklistRelation
-from program.db.db_functions import reset_streams, blacklist_stream
+from program.db.db_functions import reset_streams, blacklist_stream, delete_media_item, delete_media_item_by_id, \
+    delete_media_item_by_item_id, delete_media_items_by_ids
 
 
 @pytest.fixture(scope="session")
@@ -127,3 +128,230 @@ def test_successfully_resets_streams(test_scoped_db_session):
 
     assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=media_item._id).count() == 0
     assert test_scoped_db_session.query(StreamBlacklistRelation).filter_by(media_item_id=media_item._id).count() == 0
+
+def test_delete_media_item_success(test_scoped_db_session):
+    media_item = MediaItem({"name":"New MediaItem"})
+    media_item.item_id = "tt123456"
+    test_scoped_db_session.add(media_item)
+
+    stream1 = Stream(Torrent(
+        raw_title="Example.Movie.2020.1080p.BluRay.x264-Example",
+        infohash="997592a005d9c162391803c615975676738d6a11",
+        data=ParsedData(parsed_title='Example Movie'),
+        fetch=True,
+        rank=150,
+        lev_ratio=0.9
+    ))
+    test_scoped_db_session.add(stream1)
+    test_scoped_db_session.commit()
+    
+    stream_relation1 = StreamRelation(parent_id=media_item._id, child_id=stream1._id)
+    test_scoped_db_session.add(stream_relation1)
+    test_scoped_db_session.commit()
+
+    assert test_scoped_db_session.query(MediaItem).filter_by(_id=media_item._id).count() == 1
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=media_item._id).count() == 1
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream1._id).count() == 1
+    
+    delete_media_item(media_item)
+
+    assert test_scoped_db_session.query(MediaItem).filter_by(_id=media_item._id).count() == 0
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=media_item._id).count() == 0
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream1._id).count() == 0
+
+def test_delete_show_with_seasons_and_episodes_success(test_scoped_db_session):
+    show = Show({"title": "New Show"})
+    show.item_id = "tt654321"
+    test_scoped_db_session.add(show)
+    test_scoped_db_session.commit()
+
+    season1 = Season({"number": 1, "parent": show})
+    season1.parent_id = show._id
+    test_scoped_db_session.add(season1)
+    test_scoped_db_session.commit()
+
+    episode1 = Episode({"number": 1})
+    episode2 = Episode({"number": 2})
+    episode1.parent_id = season1._id
+    episode2.parent_id = season1._id
+    test_scoped_db_session.add(episode1)
+    test_scoped_db_session.add(episode2)
+    test_scoped_db_session.commit()
+
+    stream1 = Stream(Torrent(
+        raw_title="Example.Show.S01E01.1080p.BluRay.x264-Example",
+        infohash="abcd1234abcd1234abcd1234abcd1234abcd1234",
+        data=ParsedData(parsed_title='Example Show'),
+        fetch=True,
+        rank=200,
+        lev_ratio=0.95
+    ))
+    test_scoped_db_session.add(stream1)
+    test_scoped_db_session.commit()
+
+    stream_relation1 = StreamRelation(parent_id=show._id, child_id=stream1._id)
+    test_scoped_db_session.add(stream_relation1)
+    test_scoped_db_session.commit()
+
+    assert test_scoped_db_session.query(Show).filter_by(_id=show._id).count() == 1
+    assert test_scoped_db_session.query(Season).filter_by(parent_id=show._id).count() == 1
+    assert test_scoped_db_session.query(Episode).filter_by(parent_id=season1._id).count() == 2
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=show._id).count() == 1
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream1._id).count() == 1
+
+    delete_media_item(show)
+
+    assert test_scoped_db_session.query(Show).filter_by(_id=show._id).count() == 0
+    assert test_scoped_db_session.query(Season).filter_by(parent_id=show._id).count() == 0
+    assert test_scoped_db_session.query(Episode).filter_by(parent_id=season1._id).count() == 0
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=show._id).count() == 0
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream1._id).count() == 0
+
+def test_delete_show_by_id_with_seasons_and_episodes_success(test_scoped_db_session):
+    show = Show({"title": "New Show"})
+    show.item_id = "tt654321"
+    test_scoped_db_session.add(show)
+    test_scoped_db_session.commit()
+
+    season1 = Season({"number": 1, "parent": show})
+    season1.parent_id = show._id
+    test_scoped_db_session.add(season1)
+    test_scoped_db_session.commit()
+
+    episode1 = Episode({"number": 1})
+    episode2 = Episode({"number": 2})
+    episode1.parent_id = season1._id
+    episode2.parent_id = season1._id
+    test_scoped_db_session.add(episode1)
+    test_scoped_db_session.add(episode2)
+    test_scoped_db_session.commit()
+
+    stream1 = Stream(Torrent(
+        raw_title="Example.Show.S01E01.1080p.BluRay.x264-Example",
+        infohash="abcd1234abcd1234abcd1234abcd1234abcd1234",
+        data=ParsedData(parsed_title='Example Show'),
+        fetch=True,
+        rank=200,
+        lev_ratio=0.95
+    ))
+    test_scoped_db_session.add(stream1)
+    test_scoped_db_session.commit()
+
+    stream_relation1 = StreamRelation(parent_id=show._id, child_id=stream1._id)
+    test_scoped_db_session.add(stream_relation1)
+    test_scoped_db_session.commit()
+
+    assert test_scoped_db_session.query(Show).filter_by(_id=show._id).count() == 1
+    assert test_scoped_db_session.query(Season).filter_by(parent_id=show._id).count() == 1
+    assert test_scoped_db_session.query(Episode).filter_by(parent_id=season1._id).count() == 2
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=show._id).count() == 1
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream1._id).count() == 1
+
+    delete_media_item_by_id(show._id)
+
+    assert test_scoped_db_session.query(Show).filter_by(_id=show._id).count() == 0
+    assert test_scoped_db_session.query(Season).filter_by(parent_id=show._id).count() == 0
+    assert test_scoped_db_session.query(Episode).filter_by(parent_id=season1._id).count() == 0
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=show._id).count() == 0
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream1._id).count() == 0
+
+def test_delete_show_by_item_id_with_seasons_and_episodes_success(test_scoped_db_session):
+    show = Show({"title": "New Show"})
+    show.item_id = "tt654321"
+    test_scoped_db_session.add(show)
+    test_scoped_db_session.commit()
+
+    season1 = Season({"number": 1, "parent": show})
+    season1.parent_id = show._id
+    test_scoped_db_session.add(season1)
+    test_scoped_db_session.commit()
+
+    episode1 = Episode({"number": 1})
+    episode2 = Episode({"number": 2})
+    episode1.parent_id = season1._id
+    episode2.parent_id = season1._id
+    test_scoped_db_session.add(episode1)
+    test_scoped_db_session.add(episode2)
+    test_scoped_db_session.commit()
+
+    stream1 = Stream(Torrent(
+        raw_title="Example.Show.S01E01.1080p.BluRay.x264-Example",
+        infohash="abcd1234abcd1234abcd1234abcd1234abcd1234",
+        data=ParsedData(parsed_title='Example Show'),
+        fetch=True,
+        rank=200,
+        lev_ratio=0.95
+    ))
+    test_scoped_db_session.add(stream1)
+    test_scoped_db_session.commit()
+
+    stream_relation1 = StreamRelation(parent_id=show._id, child_id=stream1._id)
+    test_scoped_db_session.add(stream_relation1)
+    test_scoped_db_session.commit()
+
+    assert test_scoped_db_session.query(Show).filter_by(_id=show._id).count() == 1
+    assert test_scoped_db_session.query(Season).filter_by(parent_id=show._id).count() == 1
+    assert test_scoped_db_session.query(Episode).filter_by(parent_id=season1._id).count() == 2
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=show._id).count() == 1
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream1._id).count() == 1
+
+    delete_media_item_by_item_id(show.item_id)
+
+    assert test_scoped_db_session.query(Show).filter_by(_id=show._id).count() == 0
+    assert test_scoped_db_session.query(Season).filter_by(parent_id=show._id).count() == 0
+    assert test_scoped_db_session.query(Episode).filter_by(parent_id=season1._id).count() == 0
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=show._id).count() == 0
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream1._id).count() == 0
+
+def test_delete_media_items_by_ids_success(test_scoped_db_session):
+    media_item1 = MediaItem({"name": "New MediaItem 1"})
+    media_item1.item_id = "tt123456"
+    test_scoped_db_session.add(media_item1)
+
+    media_item2 = MediaItem({"name": "New MediaItem 2"})
+    media_item2.item_id = "tt654321"
+    test_scoped_db_session.add(media_item2)
+
+    stream1 = Stream(Torrent(
+        raw_title="Example.Movie.2020.1080p.BluRay.x264-Example",
+        infohash="997592a005d9c162391803c615975676738d6a11",
+        data=ParsedData(parsed_title='Example Movie'),
+        fetch=True,
+        rank=150,
+        lev_ratio=0.9
+    ))
+    test_scoped_db_session.add(stream1)
+
+    stream2 = Stream(Torrent(
+        raw_title="Another.Movie.2021.720p.WEBRip.x264-Another",
+        infohash="997592a005d9c162391803c615975676738d6a12",
+        data=ParsedData(parsed_title='Another Movie'),
+        fetch=True,
+        rank=200,
+        lev_ratio=0.85
+    ))
+    test_scoped_db_session.add(stream2)
+    test_scoped_db_session.commit()
+
+    stream_relation1 = StreamRelation(parent_id=media_item1._id, child_id=stream1._id)
+    stream_relation2 = StreamRelation(parent_id=media_item2._id, child_id=stream2._id)
+    test_scoped_db_session.add(stream_relation1)
+    test_scoped_db_session.add(stream_relation2)
+    test_scoped_db_session.commit()
+
+    assert test_scoped_db_session.query(MediaItem).filter_by(_id=media_item1._id).count() == 1
+    assert test_scoped_db_session.query(MediaItem).filter_by(_id=media_item2._id).count() == 1
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=media_item1._id).count() == 1
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=media_item2._id).count() == 1
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream1._id).count() == 1
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream2._id).count() == 1
+    assert media_item1._id != media_item2._id
+
+    delete_media_items_by_ids([media_item1._id, media_item2._id])
+
+    assert test_scoped_db_session.query(MediaItem).filter_by(_id=media_item1._id).count() == 0
+    assert test_scoped_db_session.query(MediaItem).filter_by(_id=media_item2._id).count() == 0
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=media_item1._id).count() == 0
+    assert test_scoped_db_session.query(StreamRelation).filter_by(parent_id=media_item2._id).count() == 0
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream1._id).count() == 0
+    assert test_scoped_db_session.query(Stream).filter_by(_id=stream2._id).count() == 0


### PR DESCRIPTION
- Introduced `delete_media_item`, `delete_media_item_by_id`, `delete_media_item_by_item_id`, and `delete_media_items_by_ids` functions in `db_functions.py` to handle deletion of MediaItems and their associated relationships.
- Updated `MediaItem` relationships to include cascade delete options.
- Refactored `remove_item` endpoint in `items.py` to use the new deletion functions.
- Added tests for the new deletion functions in `test_db_functions.py`.
