### PR TITLE
feat: Add `get_media_items_by_ids` function and integrate it into item removal process

### DIFF
--- a/src/program/db/db_functions.py
+++ b/src/program/db/db_functions.py
@@ -16,6 +16,21 @@ from .db import db, alembic
 if TYPE_CHECKING:
     from program.media.item import MediaItem
 
+def get_media_items_by_ids(media_item_ids: list[int]):
+    """Retrieve multiple MediaItems by a list of MediaItem _ids using the _get_item_from_db method."""
+    from program.media.item import MediaItem
+    items = []
+
+    with db.Session() as session:
+        for media_item_id in media_item_ids:
+            dummy_item = MediaItem({})
+            dummy_item._id = media_item_id
+            item = _get_item_from_db(session, dummy_item)
+            if item:
+                items.append(item)
+
+    return items
+
 def delete_media_item(item: "MediaItem"):
     """Delete a MediaItem and all its associated relationships."""
     with db.Session() as session:


### PR DESCRIPTION
- Introduced `get_media_items_by_ids` function in `db_functions.py` to retrieve multiple MediaItems by their IDs.
- Updated `remove_item` endpoint in `items.py` to use `get_media_items_by_ids` for validating and deleting media items.
- Added unit test `test_get_media_items_by_ids_success` in `test_db_functions.py` to verify the functionality of `get_media_items_by_ids`.
