### PR TITLE
ci: build dev image from main

### DIFF
--- a/.github/workflows/docker-build-dev.yml
+++ b/.github/workflows/docker-build-dev.yml
@@ -3,7 +3,7 @@ name: Docker Build and Push Dev
 on:
   push:
     branches:
-      - dev
+      - main
 
 jobs:
   build-and-push-dev:


### PR DESCRIPTION
- Build dev image from main, workflow should be PR -> main, not PR -> branch -> main.

Release-As: 0.10.5