### PR TITLE
fix: updated settings.json variables for opensubtitles

### DIFF
--- a/src/program/settings/models.py
+++ b/src/program/settings/models.py
@@ -363,12 +363,12 @@ class SubliminalConfig(Observable):
             "username": "",
             "password": ""
         },
-        "opensubtitlesvip": {
+        "opensubtitles": {
             "enabled": False,
             "username": "",
             "password": ""
         },
-        "opensubtitlescomvip": {
+        "opensubtitlescom": {
             "enabled": False,
             "username": "",
             "password": ""


### PR DESCRIPTION
settings.json values for subtitle providers opensubtitlescom opensubtitles needs to be corrected to name without vip, post_processing/subliminal line:22 looks for values of providers without the vip.