### PR TITLE
fix: support files in rclone root

### DIFF
--- a/src/program/symlink.py
+++ b/src/program/symlink.py
@@ -354,4 +354,9 @@ def get_item_path(item: Union[Movie, Episode]) -> Optional[Path]:
             file_path = rclone_path / folder / item.file
             if file_path.exists():
                 return file_path
+
+    # Not in a folder? Perhaps it's just sitting in the root.
+    file = rclone_path / item.file
+    if file.exists() and file.is_file():
+        return file
     return None


### PR DESCRIPTION
## Description:

Files can sometimes be sitting in the root of the webdav mount. This fix updates the symlinker to find those files.