### PR TITLE
test: fix failing symlink library tests

### DIFF
--- a/src/tests/test_symlink_library.py
+++ b/src/tests/test_symlink_library.py
@@ -11,7 +11,11 @@ from program.settings.manager import settings_manager
 
 class MockSettings:
     def __init__(self, library_path):
-        self.symlink = type("symlink", (), {"library_path": Path(library_path)})
+        self.force_refresh = False
+        self.symlink = type("symlink", (), {
+            "library_path": Path(library_path),
+            "separate_anime_dirs": True,
+        })
 
 @pytest.fixture
 def symlink_library(fs):


### PR DESCRIPTION
## Description:

Small change to get pytest passing for the symlink library. Some mandatory settings have been added since these tests were written.