### PR TITLE
refactor: use an abstract base class for downloaders

### DIFF
--- a/src/controllers/items.py
+++ b/src/controllers/items.py
@@ -20,16 +20,12 @@ from program.db.db_functions import (
     get_parent_ids,
     reset_media_item,
 )
-from program.downloaders import Downloader, get_needed_media
-from program.downloaders.realdebrid import (
-    add_torrent_magnet,
-    torrent_info,
-)
 from program.media.item import MediaItem
 from program.media.state import States
+from program.symlink import Symlinker
+from program.downloaders import Downloader, get_needed_media
 from program.media.stream import Stream
 from program.scrapers.shared import rtn
-from program.symlink import Symlinker
 from program.types import Event
 from pydantic import BaseModel
 from RTN import Torrent
@@ -344,7 +340,7 @@ async def remove_item(request: Request, ids: str) -> RemoveResponse:
         media_items: list[int] = get_parent_ids(ids)
         if not media_items:
             return HTTPException(status_code=404, detail="Item(s) not found")
-        
+
         for media_item in media_items:
             logger.debug(f"Removing item with ID {media_item}")
             request.app.program.em.cancel_job_by_id(media_item)
@@ -384,8 +380,9 @@ class SetTorrentRDResponse(BaseModel):
 )
 def add_torrent(request: Request, id: int, magnet: str) -> SetTorrentRDResponse:
     torrent_id = ""
+    downloader: Downloader = request.app.program.services.get(Downloader)
     try:
-        torrent_id = add_torrent_magnet(magnet)
+        torrent_id = downloader.add_torrent_magnet(magnet)
     except Exception:
         raise HTTPException(status_code=500, detail="Failed to add torrent.") from None
 
@@ -437,7 +434,7 @@ def set_torrent_rd(request: Request, id: int, torrent_id: str) -> SetTorrentRDRe
         if item is None:
             raise HTTPException(status_code=404, detail="Item not found")
 
-        fetched_torrent_info = torrent_info(torrent_id)
+        fetched_torrent_info = downloader.get_torrent_info(torrent_id)
 
         stream = (
             session.execute(

--- a/src/program/downloaders/__init__.py
+++ b/src/program/downloaders/__init__.py
@@ -2,7 +2,7 @@ from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
 
 from program.media.item import MediaItem
 from program.settings.manager import settings_manager
-from utils.logger import logger
+from loguru import logger
 
 from .alldebrid import AllDebridDownloader
 from .realdebrid import RealDebridDownloader
@@ -107,6 +107,14 @@ class Downloader:
         torrent_names = self.service.get_torrent_names(torrent_id)
         update_item_attributes(item, torrent_names)
         logger.log("DEBRID", f"Downloaded {item.log_string} from '{item.active_stream['name']}' [{item.active_stream['infohash']}]")
+
+    def add_torrent_magnet(self, magnet_link: str):
+        return self.service.add_torrent_magnet(magnet_link)
+
+
+    def get_torrent_info(self, torrent_id: str):
+        return self.service.get_torrent_info(torrent_id)
+
 
 def update_item_attributes(item: MediaItem, names: tuple[str, str]):
     """ Update the item attributes with the downloaded files and active stream """

--- a/src/program/downloaders/__init__.py
+++ b/src/program/downloaders/__init__.py
@@ -14,26 +14,36 @@ class Downloader:
     def __init__(self):
         self.key = "downloader"
         self.initialized = False
-        self.speed_mode = settings_manager.settings.downloaders.prefer_speed_over_quality
+        self.speed_mode = (
+            settings_manager.settings.downloaders.prefer_speed_over_quality
+        )
         self.services = {
             RealDebridDownloader: RealDebridDownloader(),
             AllDebridDownloader: AllDebridDownloader(),
-            #TorBoxDownloader: TorBoxDownloader()
+            # TorBoxDownloader: TorBoxDownloader()
         }
-        self.service = next((service for service in self.services.values() if service.initialized), None)
+        self.service = next(
+            (service for service in self.services.values() if service.initialized), None
+        )
 
         self.initialized = self.validate()
 
     def validate(self):
         if self.service is None:
-            logger.error("No downloader service is initialized. Please initialize a downloader service.")
+            logger.error(
+                "No downloader service is initialized. Please initialize a downloader service."
+            )
             return False
         return True
 
     def run(self, item: MediaItem):
         logger.debug(f"Running downloader for {item.log_string}")
         needed_media = get_needed_media(item)
-        hashes = [stream.infohash for stream in item.streams if stream.infohash not in self.service.existing_hashes]
+        hashes = [
+            stream.infohash
+            for stream in item.streams
+            if stream.infohash not in self.service.existing_hashes
+        ]
         cached_streams = self.get_cached_streams(hashes, needed_media)
         if len(cached_streams) > 0:
             item.active_stream = cached_streams[0]
@@ -53,21 +63,34 @@ class Downloader:
         try:
             self.service.existing_hashes.remove(item.active_stream["infohash"])
             self.service.delete_torrent_with_infohash(item.active_stream["infohash"])
-            stream = next((stream for stream in item.streams if stream.infohash == item.active_stream["infohash"]), None)
+            stream = next(
+                (
+                    stream
+                    for stream in item.streams
+                    if stream.infohash == item.active_stream["infohash"]
+                ),
+                None,
+            )
             if stream:
                 item.blacklist_stream(stream)
         except Exception as e:
-            logger.debug(f"Failed to delete and reset active stream for {item.log_string}: {e}")
+            logger.debug(
+                f"Failed to delete and reset active stream for {item.log_string}: {e}"
+            )
         item.active_stream = {}
 
-    def get_cached_streams(self, hashes: list[str], needed_media, break_on_first = True) -> dict:
-        chunks = [hashes[i:i + 5] for i in range(0, len(hashes), 5)]
+    def get_cached_streams(
+        self, hashes: list[str], needed_media, break_on_first=True
+    ) -> dict:
+        chunks = [hashes[i : i + 5] for i in range(0, len(hashes), 5)]
         # Using a list to share the state, booleans are immutable
         break_pointer = [False, break_on_first]
         results = []
         priority_index = 0
 
-        with ThreadPoolExecutor(thread_name_prefix="Downloader", max_workers=4) as executor:
+        with ThreadPoolExecutor(
+            thread_name_prefix="Downloader", max_workers=4
+        ) as executor:
             futures = []
 
             def cancel_all():
@@ -75,7 +98,9 @@ class Downloader:
                     f.cancel()
 
             for chunk in chunks:
-                future = executor.submit(self.service.process_hashes, chunk, needed_media, break_pointer)
+                future = executor.submit(
+                    self.service.process_hashes, chunk, needed_media, break_pointer
+                )
                 futures.append(future)
 
             for future in as_completed(futures):
@@ -97,7 +122,7 @@ class Downloader:
                             return results
                     # Uncached
                     elif infohash == hashes[priority_index]:
-                            priority_index += 1
+                        priority_index += 1
 
         results.sort(key=lambda x: hashes.index(x["infohash"]))
         return results
@@ -106,26 +131,37 @@ class Downloader:
         torrent_id = self.service.download_cached(active_stream)
         torrent_names = self.service.get_torrent_names(torrent_id)
         update_item_attributes(item, torrent_names)
-        logger.log("DEBRID", f"Downloaded {item.log_string} from '{item.active_stream['name']}' [{item.active_stream['infohash']}]")
+        logger.log(
+            "DEBRID",
+            f"Downloaded {item.log_string} from '{item.active_stream['name']}' [{item.active_stream['infohash']}]",
+        )
 
     def add_torrent_magnet(self, magnet_link: str):
         return self.service.add_torrent_magnet(magnet_link)
-
 
     def get_torrent_info(self, torrent_id: str):
         return self.service.get_torrent_info(torrent_id)
 
 
 def update_item_attributes(item: MediaItem, names: tuple[str, str]):
-    """ Update the item attributes with the downloaded files and active stream """
+    """Update the item attributes with the downloaded files and active stream"""
     matches_dict = item.active_stream.get("matched_files")
     item.folder = names[0]
     item.alternative_folder = names[1]
-    stream = next((stream for stream in item.streams if stream.infohash == item.active_stream["infohash"]), None)
+    stream = next(
+        (
+            stream
+            for stream in item.streams
+            if stream.infohash == item.active_stream["infohash"]
+        ),
+        None,
+    )
     item.active_stream["name"] = stream.raw_title
 
     if item.type in ["movie", "episode"]:
-        item.file = next(file["filename"] for file in next(iter(matches_dict.values())).values())
+        item.file = next(
+            file["filename"] for file in next(iter(matches_dict.values())).values()
+        )
     elif item.type == "show":
         for season in item.seasons:
             for episode in season.episodes:
@@ -134,7 +170,10 @@ def update_item_attributes(item: MediaItem, names: tuple[str, str]):
                     episode.file = file["filename"]
                     episode.folder = item.folder
                     episode.alternative_folder = item.alternative_folder
-                    episode.active_stream = {**item.active_stream, "files": [ episode.file ] }
+                    episode.active_stream = {
+                        **item.active_stream,
+                        "files": [episode.file],
+                    }
     elif item.type == "season":
         for episode in item.episodes:
             file = matches_dict.get(item.number, {}).get(episode.number, {})
@@ -142,4 +181,4 @@ def update_item_attributes(item: MediaItem, names: tuple[str, str]):
                 episode.file = file["filename"]
                 episode.folder = item.folder
                 episode.alternative_folder = item.alternative_folder
-                episode.active_stream = {**item.active_stream, "files": [ episode.file ] }
+                episode.active_stream = {**item.active_stream, "files": [episode.file]}

--- a/src/program/downloaders/alldebrid.py
+++ b/src/program/downloaders/alldebrid.py
@@ -116,7 +116,7 @@ class AllDebridDownloader(DownloaderBase):
             # We avoid compressed downloads this way
             def all_files_valid(files: list) -> bool:
                 filenames = [f.lower() for f, _ in walk_alldebrid_files(files)]
-                return all(
+                return len(filenames) >= 1 and all(
                     "sample" not in file and file.rsplit(".", 1)[-1] in VIDEO_EXTENSIONS
                     for file in filenames
                 )

--- a/src/program/downloaders/alldebrid.py
+++ b/src/program/downloaders/alldebrid.py
@@ -7,8 +7,14 @@ from typing import Optional
 from utils import request
 from utils.ratelimiter import RateLimiter
 
-from .shared import VIDEO_EXTENSIONS, FileFinder, DownloaderBase, premium_days_left, hash_from_uri
-from .shared import DebridTorrentId, InfoHash # Types
+from .shared import (
+    VIDEO_EXTENSIONS,
+    FileFinder,
+    DownloaderBase,
+    premium_days_left,
+    hash_from_uri,
+)
+from .shared import DebridTorrentId, InfoHash  # Types
 
 AD_BASE_URL = "https://api.alldebrid.com/v4"
 AD_AGENT = "Riven"
@@ -142,9 +148,9 @@ class AllDebridDownloader(DownloaderBase):
         if id:
             delete_torrent(id)
 
-
     def get_torrent_info(self, torrent_id: DebridTorrentId) -> dict:
         return get_status(torrent_id)
+
 
 def walk_alldebrid_files(files: list[dict]) -> (str, int):
     """Walks alldebrid's `files` nested dicts and returns (filename, filesize) for each file, discarding path information"""
@@ -171,9 +177,11 @@ def get(url, **params) -> dict:
         response_type=dict,
         specific_rate_limiter=inner_rate_limit,
         overall_rate_limiter=overall_rate_limiter,
-        proxies=settings.settings.downloaders.all_debrid.proxy_url
-        if settings.settings.downloaders.all_debrid.proxy_enabled
-        else None,
+        proxies=(
+            settings.settings.downloaders.all_debrid.proxy_url
+            if settings.settings.downloaders.all_debrid.proxy_enabled
+            else None
+        ),
     ).data
 
 
@@ -196,10 +204,8 @@ def get_instant_availability(infohashes: list[InfoHash]) -> list[dict]:
 
 def add_torrent(infohash: str) -> DebridTorrentId:
     try:
-        params={"magnets[]": infohash}
-        id = get(
-            "magnet/upload", **params
-        )["data"]["magnets"][0]["id"]
+        params = {"magnets[]": infohash}
+        id = get("magnet/upload", **params)["data"]["magnets"][0]["id"]
     except Exception:
         logger.warning(f"Failed to add torrent with infohash {infohash}")
         id = None
@@ -225,6 +231,7 @@ def get_torrents() -> list[dict]:
         logger.warning("Failed to get torrents.")
         torrents = []
     return torrents
+
 
 def delete_torrent(id: str):
     try:

--- a/src/program/downloaders/alldebrid.py
+++ b/src/program/downloaders/alldebrid.py
@@ -3,10 +3,12 @@ from datetime import datetime
 from loguru import logger
 from program.settings.manager import settings_manager as settings
 from requests import ConnectTimeout
+from typing import Optional
 from utils import request
 from utils.ratelimiter import RateLimiter
 
-from .shared import VIDEO_EXTENSIONS, FileFinder, premium_days_left
+from .shared import VIDEO_EXTENSIONS, FileFinder, DownloaderBase, premium_days_left, hash_from_uri
+from .shared import DebridTorrentId, InfoHash # Types
 
 AD_BASE_URL = "https://api.alldebrid.com/v4"
 AD_AGENT = "Riven"
@@ -15,7 +17,7 @@ inner_rate_limit = RateLimiter(12, 1)  # 12 requests per second
 overall_rate_limiter = RateLimiter(600, 60)  # 600 requests per minute
 
 
-class AllDebridDownloader:
+class AllDebridDownloader(DownloaderBase):
     """All-Debrid API Wrapper"""
 
     def __init__(self):
@@ -60,19 +62,29 @@ class AllDebridDownloader:
         return False
 
     def process_hashes(
-        self, chunk: list[str], needed_media: dict, break_pointer: list[bool]
+        self, chunk: list[InfoHash], needed_media: dict, break_pointer: list[bool]
     ) -> dict:
         return self.get_cached_containers(chunk, needed_media, break_pointer)
 
-    def download_cached(self, active_stream: dict) -> str:
+    def download_cached(self, active_stream: dict) -> DebridTorrentId:
         torrent_id = add_torrent(active_stream.get("infohash"))
         if torrent_id:
             self.existing_hashes.append(active_stream.get("infohash"))
-            return torrent_id
+            return str(torrent_id)
+        raise Exception("Failed to download torrent.")
+
+    def add_torrent_magnet(self, magnet_uri: str) -> DebridTorrentId:
+        hash = hash_from_uri(magnet_uri)
+        if not hash:
+            raise Exception(f"Bad magnet: {magnet_uri}")
+        torrent_id = add_torrent(hash)
+        if torrent_id:
+            self.existing_hashes.append(hash)
+            return str(torrent_id)
         raise Exception("Failed to download torrent.")
 
     def get_cached_containers(
-        self, infohashes: list[str], needed_media: dict, break_pointer: list[bool]
+        self, infohashes: list[InfoHash], needed_media: dict, break_pointer: list[bool]
     ) -> dict:
         """
         Get containers that are available in the debrid cache containing `needed_media`
@@ -119,11 +131,11 @@ class AllDebridDownloader:
 
         return cached_containers
 
-    def get_torrent_names(self, id: str) -> dict:
+    def get_torrent_names(self, id: DebridTorrentId) -> tuple[str, Optional[str]]:
         info = get_status(id)
-        return info["filename"], info["filename"]
+        return info["filename"], None
 
-    def delete_torrent_with_infohash(self, infohash: str):
+    def delete_torrent_with_infohash(self, infohash: InfoHash):
         id = next(
             torrent["id"] for torrent in get_torrents() if torrent["hash"] == infohash
         )
@@ -131,7 +143,10 @@ class AllDebridDownloader:
             delete_torrent(id)
 
 
-def walk_alldebrid_files(files: dict) -> (str, int):
+    def get_torrent_info(self, torrent_id: DebridTorrentId) -> dict:
+        return get_status(torrent_id)
+
+def walk_alldebrid_files(files: list[dict]) -> (str, int):
     """Walks alldebrid's `files` nested dicts and returns (filename, filesize) for each file, discarding path information"""
     dirs = []
     for f in files:
@@ -166,7 +181,7 @@ def get_user() -> dict:
     return get("user")
 
 
-def get_instant_availability(infohashes: list[str]) -> list[dict]:
+def get_instant_availability(infohashes: list[InfoHash]) -> list[dict]:
     try:
         params = dict(
             (f"magnets[{i}]", infohash) for i, infohash in enumerate(infohashes)
@@ -179,9 +194,9 @@ def get_instant_availability(infohashes: list[str]) -> list[dict]:
     return magnets
 
 
-def add_torrent(infohash: str) -> int:
+def add_torrent(infohash: str) -> DebridTorrentId:
     try:
-        params={"magnets[]": f"magnet:?xt=urn:btih:{infohash}"}
+        params={"magnets[]": infohash}
         id = get(
             "magnet/upload", **params
         )["data"]["magnets"][0]["id"]
@@ -193,7 +208,7 @@ def add_torrent(infohash: str) -> int:
 
 def get_status(id: str) -> dict:
     try:
-        info = get("magnet/status", id=f"{id}")["data"]["magnets"]
+        info = get("magnet/status", id=id)["data"]["magnets"]
         # Error if filename not present
         info.get("filename")
     except Exception:

--- a/src/program/downloaders/realdebrid.py
+++ b/src/program/downloaders/realdebrid.py
@@ -10,6 +10,7 @@ from utils import request
 from utils.ratelimiter import RateLimiter
 
 from .shared import VIDEO_EXTENSIONS, FileFinder, DownloaderBase, premium_days_left
+
 # Types
 from .shared import InfoHash, DebridTorrentId
 
@@ -17,6 +18,7 @@ BASE_URL = "https://api.real-debrid.com/rest/1.0"
 
 torrent_limiter = RateLimiter(1, 1)
 overall_limiter = RateLimiter(60, 60)
+
 
 class RDTorrentStatus(str, Enum):
     magnet_error = "magnet_error"
@@ -30,6 +32,7 @@ class RDTorrentStatus(str, Enum):
     uploading = "uploading"
     compressing = "compressing"
 
+
 class RDTorrent(BaseModel):
     id: str
     hash: str
@@ -42,7 +45,9 @@ class RDTorrent(BaseModel):
     speed: Optional[int] = None
     seeders: Optional[int] = None
 
+
 rd_torrent_list = TypeAdapter(list[RDTorrent])
+
 
 class RealDebridDownloader(DownloaderBase):
     def __init__(self):
@@ -67,7 +72,9 @@ class RealDebridDownloader(DownloaderBase):
             user_info = get("/user")
             if user_info:
                 expiration = user_info.get("expiration", "")
-                expiration_datetime = datetime.fromisoformat(expiration.replace("Z", "+00:00")).replace(tzinfo=None)
+                expiration_datetime = datetime.fromisoformat(
+                    expiration.replace("Z", "+00:00")
+                ).replace(tzinfo=None)
                 expiration_message = premium_days_left(expiration_datetime)
 
                 if user_info.get("type", "") != "premium":
@@ -85,19 +92,27 @@ class RealDebridDownloader(DownloaderBase):
             logger.error("Couldn't parse user data response from Real-Debrid.")
         return False
 
-    def process_hashes(self, chunk: list[InfoHash], needed_media: dict, break_pointer: list[bool]) -> dict:
-        cached_containers = self.get_cached_containers(chunk, needed_media, break_pointer)
+    def process_hashes(
+        self, chunk: list[InfoHash], needed_media: dict, break_pointer: list[bool]
+    ) -> dict:
+        cached_containers = self.get_cached_containers(
+            chunk, needed_media, break_pointer
+        )
         return cached_containers
 
     def download_cached(self, active_stream: dict) -> DebridTorrentId:
         torrent_id = add_torrent(active_stream.get("infohash"))
         if torrent_id:
             self.existing_hashes.append(active_stream.get("infohash"))
-            select_files(torrent_id, [file for file in active_stream.get("all_files").keys()])
+            select_files(
+                torrent_id, [file for file in active_stream.get("all_files").keys()]
+            )
             return torrent_id
         raise Exception("Failed to download torrent.")
 
-    def get_cached_containers(self, infohashes: list[str], needed_media: dict, break_pointer: list[bool]) -> dict:
+    def get_cached_containers(
+        self, infohashes: list[str], needed_media: dict, break_pointer: list[bool]
+    ) -> dict:
         cached_containers = {}
         response = get_instant_availability(infohashes)
 
@@ -112,34 +127,41 @@ class RealDebridDownloader(DownloaderBase):
                 containers = data.get("rd", [])
             else:
                 containers = []
+
             # We avoid compressed downloads this way
             def all_files_valid(file_dict: dict) -> bool:
                 return all(
                     any(
-                        file["filename"].endswith(f".{ext}") and "sample" not in file["filename"].lower()
+                        file["filename"].endswith(f".{ext}")
+                        and "sample" not in file["filename"].lower()
                         for ext in VIDEO_EXTENSIONS
                     )
                     for file in file_dict.values()
                 )
+
             # Sort the container to have the longest length first
             containers.sort(key=lambda x: len(x), reverse=True)
             for container in containers:
                 if break_pointer[1] and break_pointer[0]:
                     break
                 if all_files_valid(container):
-                    cached_containers[infohash] = self.file_finder.get_cached_container(needed_media, break_pointer, container)
+                    cached_containers[infohash] = self.file_finder.get_cached_container(
+                        needed_media, break_pointer, container
+                    )
                     if cached_containers[infohash]:
                         break_pointer[0] = True
                         if break_pointer[1]:
                             break
         return cached_containers
 
-    def get_torrent_names(self, id: str) -> tuple[str,str]:
+    def get_torrent_names(self, id: str) -> tuple[str, str]:
         info = torrent_info(id)
         return (info["filename"], info["original_filename"])
 
     def delete_torrent_with_infohash(self, infohash: str):
-        id = next(torrent.id for torrent in get_torrents(1000) if torrent.hash == infohash)
+        id = next(
+            torrent.id for torrent in get_torrents(1000) if torrent.hash == infohash
+        )
         if id:
             delete_torrent(id)
 
@@ -149,45 +171,69 @@ class RealDebridDownloader(DownloaderBase):
     def get_torrent_info(id: str) -> dict:
         return torrent_info(id)
 
+
 def get(url):
     return request.get(
         url=f"{BASE_URL}/{url}",
-        additional_headers={"Authorization": f"Bearer {settings.settings.downloaders.real_debrid.api_key}"},
+        additional_headers={
+            "Authorization": f"Bearer {settings.settings.downloaders.real_debrid.api_key}"
+        },
         response_type=dict,
         specific_rate_limiter=torrent_limiter,
         overall_rate_limiter=overall_limiter,
-        proxies=settings.settings.downloaders.real_debrid.proxy_url if settings.settings.downloaders.real_debrid.proxy_enabled else None
+        proxies=(
+            settings.settings.downloaders.real_debrid.proxy_url
+            if settings.settings.downloaders.real_debrid.proxy_enabled
+            else None
+        ),
     ).data
+
 
 def post(url, data):
     return request.post(
         url=f"{BASE_URL}/{url}",
         data=data,
         response_type=dict,
-        additional_headers={"Authorization": f"Bearer {settings.settings.downloaders.real_debrid.api_key}"},
+        additional_headers={
+            "Authorization": f"Bearer {settings.settings.downloaders.real_debrid.api_key}"
+        },
         specific_rate_limiter=torrent_limiter,
         overall_rate_limiter=overall_limiter,
-        proxies=settings.settings.downloaders.real_debrid.proxy_url if settings.settings.downloaders.real_debrid.proxy_enabled else None
+        proxies=(
+            settings.settings.downloaders.real_debrid.proxy_url
+            if settings.settings.downloaders.real_debrid.proxy_enabled
+            else None
+        ),
     ).data
+
 
 def delete(url):
     return request.delete(
         url=f"{BASE_URL}/{url}",
         additional_headers={
-        "Authorization": f"Bearer {settings.settings.downloaders.real_debrid.api_key}"},
+            "Authorization": f"Bearer {settings.settings.downloaders.real_debrid.api_key}"
+        },
         response_type=dict,
         specific_rate_limiter=torrent_limiter,
         overall_rate_limiter=overall_limiter,
-        proxies=settings.settings.downloaders.real_debrid.proxy_url if settings.settings.downloaders.real_debrid.proxy_enabled else None
+        proxies=(
+            settings.settings.downloaders.real_debrid.proxy_url
+            if settings.settings.downloaders.real_debrid.proxy_enabled
+            else None
+        ),
     ).data
+
 
 def add_torrent(infohash: str) -> int:
     try:
-        id = post("torrents/addMagnet", data={"magnet": f"magnet:?xt=urn:btih:{infohash}"})["id"]
+        id = post(
+            "torrents/addMagnet", data={"magnet": f"magnet:?xt=urn:btih:{infohash}"}
+        )["id"]
     except:
         logger.warning(f"Failed to add torrent with infohash {infohash}")
         id = None
     return id
+
 
 def add_torrent_magnet(magnet: str) -> str:
     try:
@@ -197,11 +243,13 @@ def add_torrent_magnet(magnet: str) -> str:
         id = None
     return id
 
+
 def select_files(id: str, files: list[str]):
     try:
         post(f"torrents/selectFiles/{id}", data={"files": ",".join(files)})
     except:
         logger.warning(f"Failed to select files for torrent with id {id}")
+
 
 def torrent_info(id: str) -> dict:
     try:
@@ -211,6 +259,7 @@ def torrent_info(id: str) -> dict:
         info = {}
     return info
 
+
 def get_torrents(limit: int) -> list[RDTorrent]:
     try:
         torrents = rd_torrent_list.validate_python(get(f"torrents?limit={str(limit)}"))
@@ -218,6 +267,7 @@ def get_torrents(limit: int) -> list[RDTorrent]:
         logger.warning("Failed to get torrents.")
         torrents = []
     return torrents
+
 
 def get_instant_availability(infohashes: list[str]) -> dict:
     try:
@@ -228,6 +278,7 @@ def get_instant_availability(infohashes: list[str]) -> dict:
         logger.warning("Failed to get instant availability.")
         data = {}
     return data
+
 
 def delete_torrent(id):
     try:

--- a/src/program/downloaders/shared.py
+++ b/src/program/downloaders/shared.py
@@ -9,17 +9,35 @@ from typing import Optional
 from datetime import datetime
 
 DEFAULT_VIDEO_EXTENSIONS = ["mp4", "mkv", "avi"]
-ALLOWED_VIDEO_EXTENSIONS = ["mp4", "mkv", "avi", "mov", "wmv", "flv", "m4v", "webm", "mpg", "mpeg", "m2ts", "ts"]
+ALLOWED_VIDEO_EXTENSIONS = [
+    "mp4",
+    "mkv",
+    "avi",
+    "mov",
+    "wmv",
+    "flv",
+    "m4v",
+    "webm",
+    "mpg",
+    "mpeg",
+    "m2ts",
+    "ts",
+]
 
-VIDEO_EXTENSIONS = settings_manager.settings.downloaders.video_extensions or DEFAULT_VIDEO_EXTENSIONS
+VIDEO_EXTENSIONS = (
+    settings_manager.settings.downloaders.video_extensions or DEFAULT_VIDEO_EXTENSIONS
+)
 VIDEO_EXTENSIONS = [ext for ext in VIDEO_EXTENSIONS if ext in ALLOWED_VIDEO_EXTENSIONS]
 
 if not VIDEO_EXTENSIONS:
     VIDEO_EXTENSIONS = DEFAULT_VIDEO_EXTENSIONS
 
 # Type aliases
-InfoHash = str # A torrent hash
-DebridTorrentId = str # Identifier issued by the debrid service for a torrent in their cache
+InfoHash = str  # A torrent hash
+DebridTorrentId = (
+    str  # Identifier issued by the debrid service for a torrent in their cache
+)
+
 
 class DownloaderBase(ABC):
     """
@@ -27,7 +45,9 @@ class DownloaderBase(ABC):
     """
 
     @abstractmethod
-    def process_hashes(self, chunk: list[InfoHash], needed_media: dict, break_pointer: list[bool]) -> dict:
+    def process_hashes(
+        self, chunk: list[InfoHash], needed_media: dict, break_pointer: list[bool]
+    ) -> dict:
         """
         Search for debrid-cached media in a list of torrent hashes, returning a dictionary with the files found.
 
@@ -82,7 +102,6 @@ class DownloaderBase(ABC):
         - infohash: Hash of the torrent.
         """
 
-
     @abstractmethod
     def add_torrent_magnet(self, magnet_uri: str) -> DebridTorrentId:
         """
@@ -101,6 +120,7 @@ class DownloaderBase(ABC):
         The returned dict has at least "hash" and "filename".
         """
 
+
 class FileFinder:
     """
     A class that helps you find files.
@@ -113,8 +133,15 @@ class FileFinder:
         self.filename_attr = name
         self.filesize_attr = size
 
-    def get_cached_container(self, needed_media: dict[int, list[int]], break_pointer: list[bool] = [False], container: dict = {}) -> dict:
-        if not needed_media or len(container) >= len([episode for season in needed_media for episode in needed_media[season]]):
+    def get_cached_container(
+        self,
+        needed_media: dict[int, list[int]],
+        break_pointer: list[bool] = [False],
+        container: dict = {},
+    ) -> dict:
+        if not needed_media or len(container) >= len(
+            [episode for season in needed_media for episode in needed_media[season]]
+        ):
             matched_files = self.cache_matches(container, needed_media, break_pointer)
             if matched_files:
                 return {"all_files": container, "matched_files": matched_files}
@@ -134,16 +161,27 @@ class FileFinder:
         except Exception:
             return None
 
-    def cache_matches(self, cached_files: dict, needed_media: dict[int, list[int]], break_pointer: list[bool] = [False]):
+    def cache_matches(
+        self,
+        cached_files: dict,
+        needed_media: dict[int, list[int]],
+        break_pointer: list[bool] = [False],
+    ):
         if needed_media:
             # Convert needed_media to a set of (season, episode) tuples
-            needed_episodes = {(season, episode) for season in needed_media for episode in needed_media[season]}
+            needed_episodes = {
+                (season, episode)
+                for season in needed_media
+                for episode in needed_media[season]
+            }
             matches_dict = {}
 
             for file in cached_files.values():
                 if break_pointer[1] and break_pointer[0]:
                     break
-                matched_season, matched_episodes = self.filename_matches_show(file[self.filename_attr])
+                matched_season, matched_episodes = self.filename_matches_show(
+                    file[self.filename_attr]
+                )
                 if matched_season and matched_episodes:
                     for episode in matched_episodes:
                         if (matched_season, episode) in needed_episodes:
@@ -155,21 +193,48 @@ class FileFinder:
             if not needed_episodes:
                 return matches_dict
         else:
-            biggest_file = max(cached_files.values(), key=lambda x: x[self.filesize_attr])
-            if biggest_file and self.filename_matches_movie(biggest_file[self.filename_attr]):
+            biggest_file = max(
+                cached_files.values(), key=lambda x: x[self.filesize_attr]
+            )
+            if biggest_file and self.filename_matches_movie(
+                biggest_file[self.filename_attr]
+            ):
                 return {1: {1: biggest_file}}
 
+
 def get_needed_media(item: MediaItem) -> dict:
-    acceptable_states = [States.Indexed, States.Scraped, States.Unknown, States.Failed, States.PartiallyCompleted, States.Ongoing]
+    acceptable_states = [
+        States.Indexed,
+        States.Scraped,
+        States.Unknown,
+        States.Failed,
+        States.PartiallyCompleted,
+        States.Ongoing,
+    ]
     if item.type == "movie":
         needed_media = None
     elif item.type == "show":
-        needed_media = {season.number: [episode.number for episode in season.episodes if episode.state in acceptable_states] for season in item.seasons if season.state in acceptable_states}
+        needed_media = {
+            season.number: [
+                episode.number
+                for episode in season.episodes
+                if episode.state in acceptable_states
+            ]
+            for season in item.seasons
+            if season.state in acceptable_states
+        }
     elif item.type == "season":
-        needed_media = {item.number: [episode.number for episode in item.episodes if episode.state in acceptable_states]}
+        needed_media = {
+            item.number: [
+                episode.number
+                for episode in item.episodes
+                if episode.state in acceptable_states
+            ]
+        }
     elif item.type == "episode":
         needed_media = {item.parent.number: [item.number]}
     return needed_media
+
 
 def premium_days_left(expiration: datetime) -> str:
     """Convert an expiration date into a message showing days remaining on the user's premium account"""
@@ -181,14 +246,17 @@ def premium_days_left(expiration: datetime) -> str:
     if days_left > 0:
         expiration_message = f"Your account expires in {days_left} days."
     elif hours_left > 0:
-        expiration_message = f"Your account expires in {hours_left} hours and {minutes_left} minutes."
+        expiration_message = (
+            f"Your account expires in {hours_left} hours and {minutes_left} minutes."
+        )
     else:
         expiration_message = "Your account expires soon."
     return expiration_message
+
 
 def hash_from_uri(magnet_uri: str) -> str:
     if len(magnet_uri) == 40:
         # Probably already a hash
         return magnet_uri
     start = magnet_uri.index("urn:btih:") + len("urn:btih:")
-    return magnet_uri[start:start+40]
+    return magnet_uri[start : start + 40]

--- a/src/program/downloaders/torbox.py
+++ b/src/program/downloaders/torbox.py
@@ -76,32 +76,39 @@ class TorBoxDownloader:
         stream_count = get_stream_count(item._id)
         processed_stream_hashes = set()  # Track processed stream hashes
         stream_hashes = {}
-    
+
         number_of_rows_per_page = 5
         total_pages = (stream_count // number_of_rows_per_page) + 1
-    
+
         for page_number in range(total_pages):
             with db.Session() as session:
-                for stream_id, infohash, stream in load_streams_in_pages(session, item._id, page_number, page_size=number_of_rows_per_page):
+                for stream_id, infohash, stream in load_streams_in_pages(
+                    session, item._id, page_number, page_size=number_of_rows_per_page
+                ):
                     stream_hash_lower = infohash.lower()
-    
+
                     if stream_hash_lower in processed_stream_hashes:
                         continue
-    
+
                     processed_stream_hashes.add(stream_hash_lower)
                     stream_hashes[stream_hash_lower] = stream
-    
+
                 cached_hashes = self.get_torrent_cached(list(stream_hashes.keys()))
                 if cached_hashes:
                     for cache in cached_hashes.values():
                         item.active_stream = cache
                         if self.find_required_files(item, cache["files"]):
                             logger.log(
-                                "DEBRID", f"Item is cached, proceeding with: {item.log_string}"
+                                "DEBRID",
+                                f"Item is cached, proceeding with: {item.log_string}",
                             )
                             item.set(
                                 "active_stream",
-                                {"hash": cache["hash"], "files": cache["files"], "id": None},
+                                {
+                                    "hash": cache["hash"],
+                                    "files": cache["files"],
+                                    "id": None,
+                                },
                             )
                             self.download(item)
                             return_value = True
@@ -114,21 +121,32 @@ class TorBoxDownloader:
                     logger.log("DEBRID", f"Item is not cached: {item.log_string}")
                     for stream in stream_hashes.values():
                         logger.log(
-                            "DEBUG", f"Blacklisting uncached hash ({stream.infohash}) for item: {item.log_string}"
+                            "DEBUG",
+                            f"Blacklisting uncached hash ({stream.infohash}) for item: {item.log_string}",
                         )
                         stream.blacklisted = True
-    
+
         return return_value
-    
+
     def get_cached_hashes(self, item: MediaItem, streams: list[str]) -> list[str]:
         """Check if the item is cached in torbox.app"""
         cached_hashes = self.get_torrent_cached(streams)
-        return {stream: cached_hashes[stream]["files"] for stream in streams if stream in cached_hashes}
+        return {
+            stream: cached_hashes[stream]["files"]
+            for stream in streams
+            if stream in cached_hashes
+        }
 
-    def get_cached_hashes(self, item: MediaItem, streams: list[str: Stream]) -> list[str]:
+    def get_cached_hashes(
+        self, item: MediaItem, streams: list[str:Stream]
+    ) -> list[str]:
         """Check if the item is cached in torbox.app"""
         cached_hashes = self.get_torrent_cached(streams)
-        return {stream: cached_hashes[stream]["files"] for stream in streams if stream in cached_hashes}
+        return {
+            stream: cached_hashes[stream]["files"]
+            for stream in streams
+            if stream in cached_hashes
+        }
 
     def download_cached(self, item: MediaItem, stream: str) -> None:
         """Download the cached item from torbox.app"""
@@ -167,8 +185,7 @@ class TorBoxDownloader:
                     needed_episode_numbers = {
                         episode.number
                         for episode in season.episodes
-                        if episode.state in acceptable_states
-                        and episode.is_released
+                        if episode.state in acceptable_states and episode.is_released
                     }
                     if needed_episode_numbers:
                         needed_episodes[season.number] = needed_episode_numbers
@@ -212,7 +229,9 @@ class TorBoxDownloader:
             for file in files:
                 if not file or not file.get("name"):
                     continue
-                if not parsed_file.seasons or parsed_file.seasons == [0]: # skip specials
+                if not parsed_file.seasons or parsed_file.seasons == [
+                    0
+                ]:  # skip specials
                     continue
                 # Check if the file's season matches the item's season or if there's only one season
                 if season_num in parsed_file.seasons or one_season:

--- a/src/tests/test_alldebrid_downloader.py
+++ b/src/tests/test_alldebrid_downloader.py
@@ -61,7 +61,7 @@ def test_download_cached(downloader):
 
 def test_get_torrent_names(downloader):
     names = downloader.get_torrent_names(123)
-    assert names == ("Ubuntu 24.04", "Ubuntu 24.04")
+    assert names == ("Ubuntu 24.04", None)
 
 
 ## API parsing tests
@@ -116,7 +116,7 @@ def test_delete(delete):
 
 # Example requests - taken from real API calls
 UBUNTU = "3648baf850d5930510c1f172b534200ebb5496e6"
-MAGNET_ID = 251993753
+MAGNET_ID = '251993753'
 @pytest.fixture
 def instant():
     """GET /magnet/instant?magnets[0]=infohash (torrent available)"""


### PR DESCRIPTION
## Description:

There are a few places where modules are calling directly into a downloader's internal helper methods, causing tight coupling to RealDebrid. Notably this was happening in `src/controllers/items.py`, which was hitting RealDebrid for torrent information even when RD wasn't the configured downloader service. This causes breakage for other downloaders.

I've introduced an abstract base class for downloaders to implement, which is mostly complete.`get_torrent` is notably still missing, but I think it's unused at the moment.

While I was changing the downloaders I ran Black across them to get some style consistency - [that commit](https://github.com/rivenmedia/riven/blob/6ad6d4ddbf01593453c12b39773c07cd028bd261/src/program/libraries/symlink.py#L105) can be kept or dropped if it's too noisy.