### PR TITLE
Plex watchlist not returning any items

### DIFF
--- a/src/program/content/plex_watchlist.py
+++ b/src/program/content/plex_watchlist.py
@@ -106,7 +106,6 @@ class PlexWatchlist:
                     imdb_id: str = next((guid.id.split("//")[-1] for guid in item.guids if guid.id.startswith("imdb://")), "")
                     if imdb_id and imdb_id.startswith("tt"):
                         watchlist_items.append(imdb_id)
-                        self.recurring_items.add(imdb_id)
                     else:
                         logger.log("NOT_FOUND", f"Unable to extract IMDb ID from {item.title} ({item.year}) with data id: {imdb_id}")
                 else:

--- a/src/program/content/plex_watchlist.py
+++ b/src/program/content/plex_watchlist.py
@@ -89,7 +89,6 @@ class PlexWatchlist:
                     imdb_id = self._extract_imdb_ids(_item.get("guids", []))
                     if imdb_id and imdb_id.startswith("tt"):
                         rss_items.append(imdb_id)
-                        self.recurring_items.add(imdb_id)
                     else:
                         logger.log("NOT_FOUND", f"Failed to extract IMDb ID from {_item['title']}")
             except Exception as e:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:

The Plex watchlist content service never returned any items because in the `_get_items_from_watchlist()` function, all the items got added to the recurring items list and got filtered out in line 74. But they should only be added to the recurring items list on line 75.