### PR TITLE
fix: MediaFusion scraper.

### DIFF
--- a/src/program/services/scrapers/mediafusion.py
+++ b/src/program/services/scrapers/mediafusion.py
@@ -10,7 +10,7 @@ from program.media.item import MediaItem
 from program.services.scrapers.shared import _get_stremio_identifier, ScraperRequestHandler
 from program.settings.manager import settings_manager
 from program.settings.models import AppModel
-from program.utils.request import create_service_session, get_rate_limit_params, RateLimitExceeded, HttpMethod
+from program.utils.request import create_service_session, get_rate_limit_params, RateLimitExceeded, HttpMethod, ResponseType
 
 
 class Mediafusion:
@@ -79,7 +79,7 @@ class Mediafusion:
         headers = {"Content-Type": "application/json"}
 
         try:
-            response = self.request_handler.execute(HttpMethod.POST, url, json=payload, additional_headers=headers)
+            response = self.request_handler.execute(HttpMethod.POST, url, overriden_response_type=ResponseType.DICT, json=payload, additional_headers=headers)
             self.encrypted_string = json.loads(response.data)["encrypted_str"]
         except Exception as e:
             logger.error(f"Failed to encrypt user data: {e}")

--- a/src/program/services/scrapers/shared.py
+++ b/src/program/services/scrapers/shared.py
@@ -22,8 +22,8 @@ class ScraperRequestHandler(BaseRequestHandler):
     def __init__(self, session: Session, response_type=ResponseType.SIMPLE_NAMESPACE, custom_exception: Optional[Type[Exception]] = None, request_logging: bool = False):
         super().__init__(session, response_type=response_type, custom_exception=custom_exception, request_logging=request_logging)
 
-    def execute(self, method: HttpMethod, endpoint: str, **kwargs) -> ResponseObject:
-        return super()._request(method, endpoint, **kwargs)
+    def execute(self, method: HttpMethod, endpoint: str, overriden_response_type: ResponseType = None, **kwargs) -> ResponseObject:
+        return super()._request(method, endpoint, overriden_response_type=overriden_response_type, **kwargs)
 
 
 def _get_stremio_identifier(item: MediaItem) -> tuple[str | None, str, str]:


### PR DESCRIPTION
- Allow scrapers to override main response type in shared base

# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced request handling by allowing specification of response type, improving flexibility in data interpretation.
  
- **Bug Fixes**
	- Maintained robust error handling for various request-related exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->