### PR TITLE
fix: detecting multiple episodes in symlink library

### DIFF
--- a/src/program/services/libraries/symlink.py
+++ b/src/program/services/libraries/symlink.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Generator
 
 from loguru import logger
 from sqla_wrapper import Session
+from PTT import parse_title
 
 from program.db.db import db
 from program.media.subtitle import Subtitle
@@ -159,29 +160,26 @@ def process_shows(directory: Path, item_type: str, is_anime: bool = False) -> Ge
             for episode in os.listdir(directory / show / season):
                 if os.path.splitext(episode)[1][1:] not in ALLOWED_VIDEO_EXTENSIONS:
                     continue
-                episode_numbers = re.findall(r"s\d+e(\d+)(?:-e(\d+))?", episode, re.IGNORECASE)
+                episode_numbers: list[int] = parse_title(episode).get("episodes", [])
                 if not episode_numbers:
                     logger.log("NOT_FOUND", f"Can't extract episode number at path {directory / show / season / episode}")
                     # Delete the episode since it can't be indexed
                     os.remove(directory / show / season / episode)
                     continue
 
-                for ep_range in episode_numbers:
-                    start_ep = int(ep_range[0])
-                    end_ep = int(ep_range[1]) if ep_range[1] else start_ep
-                    for episode_number in range(start_ep, end_ep + 1):
-                        episode_item = Episode({"number": episode_number})
-                        resolve_symlink_and_set_attrs(episode_item, Path(directory) / show / season / episode)
-                        find_subtitles(episode_item, Path(directory) / show / season / episode)
-                        if settings_manager.settings.force_refresh:
-                            episode_item.set("symlinked", True)
-                            episode_item.set("update_folder", str(Path(directory) / show / season / episode))
-                        else:
-                            episode_item.set("symlinked", True)
-                            episode_item.set("update_folder", "updated")
-                        if is_anime:
-                            episode_item.is_anime = True
-                        episodes[episode_number] = episode_item
+                for episode_number in episode_numbers:
+                    episode_item = Episode({"number": episode_number})
+                    resolve_symlink_and_set_attrs(episode_item, Path(directory) / show / season / episode)
+                    find_subtitles(episode_item, Path(directory) / show / season / episode)
+                    if settings_manager.settings.force_refresh:
+                        episode_item.set("symlinked", True)
+                        episode_item.set("update_folder", str(Path(directory) / show / season / episode))
+                    else:
+                        episode_item.set("symlinked", True)
+                        episode_item.set("update_folder", "updated")
+                    if is_anime:
+                        episode_item.is_anime = True
+                    episodes[episode_number] = episode_item
             if len(episodes) > 0:
                 for i in range(1, max(episodes.keys())+1):
                     season_item.add_episode(episodes.get(i, Episode({"number": i})))


### PR DESCRIPTION
Ensures that all episodes are found from symlink titles when ingesting symlinks into the db. Fixes an issue with symlink ingestion where files containing multiple episodes would only have one of the episodes added to the db, which causes the missing episodes to be submitted for scraping again after every db reset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced episode processing to handle multiple episodes from filenames.
	- Improved error handling for missing episode information with automatic file deletion.

- **Bug Fixes**
	- Refined logic for extracting episode numbers, leading to more reliable indexing.

- **Chores**
	- Minor adjustments to logging statements for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->