### PR TITLE
fix: correct Prowlarr capabilities

### DIFF
--- a/src/program/services/scrapers/prowlarr.py
+++ b/src/program/services/scrapers/prowlarr.py
@@ -218,7 +218,32 @@ class Prowlarr:
         """Parse the indexers from the XML content"""
         indexer_list = []
         for indexer in json.loads(json_content):
-            indexer_list.append(ProwlarrIndexer(title=indexer["name"], id=str(indexer["id"]), link=indexer["infoLink"], type=indexer["protocol"], language=indexer["language"], movie_search_capabilities=(s for s in indexer["capabilities"]["movieSearchParams"]) if  len([s for s in indexer["capabilities"]["categories"] if s["name"] == "Movies"]) > 0 else None, tv_search_capabilities=(s for s in indexer["capabilities"]["tvSearchParams"]) if  len([s for s in indexer["capabilities"]["categories"] if s["name"] == "TV"]) > 0 else None))
+            has_movies = any(
+                category["name"] == "Movies"
+                for category in indexer["capabilities"]["categories"]
+            )
+            has_tv = any(
+                category["name"] == "TV"
+                for category in indexer["capabilities"]["categories"]
+            )
+            
+            indexer_list.append(
+                ProwlarrIndexer(
+                    title=indexer["name"],
+                    id=str(indexer["id"]),
+                    link=indexer["infoLink"],
+                    type=indexer["protocol"],
+                    language=indexer["language"],
+                    movie_search_capabilities=(
+                        list(indexer["capabilities"]["movieSearchParams"])
+                        if has_movies else None
+                    ),
+                    tv_search_capabilities=(
+                        list(indexer["capabilities"]["tvSearchParams"])
+                        if has_tv else None
+                    )
+                )
+            )
 
         return indexer_list
 

--- a/src/program/services/scrapers/prowlarr.py
+++ b/src/program/services/scrapers/prowlarr.py
@@ -218,7 +218,7 @@ class Prowlarr:
         """Parse the indexers from the XML content"""
         indexer_list = []
         for indexer in json.loads(json_content):
-            indexer_list.append(ProwlarrIndexer(title=indexer["name"], id=str(indexer["id"]), link=indexer["infoLink"], type=indexer["protocol"], language=indexer["language"], movie_search_capabilities=(s[0] for s in indexer["capabilities"]["movieSearchParams"]) if  len([s for s in indexer["capabilities"]["categories"] if s["name"] == "Movies"]) > 0 else None, tv_search_capabilities=(s[0] for s in indexer["capabilities"]["tvSearchParams"]) if  len([s for s in indexer["capabilities"]["categories"] if s["name"] == "TV"]) > 0 else None))
+            indexer_list.append(ProwlarrIndexer(title=indexer["name"], id=str(indexer["id"]), link=indexer["infoLink"], type=indexer["protocol"], language=indexer["language"], movie_search_capabilities=(s for s in indexer["capabilities"]["movieSearchParams"]) if  len([s for s in indexer["capabilities"]["categories"] if s["name"] == "Movies"]) > 0 else None, tv_search_capabilities=(s for s in indexer["capabilities"]["tvSearchParams"]) if  len([s for s in indexer["capabilities"]["categories"] if s["name"] == "TV"]) > 0 else None))
 
         return indexer_list
 


### PR DESCRIPTION
## Description:

The current `_get_indexer_from_json()` private method only stores the first character of an indexer's `movieSearchParams`/`tvSearchParams`, resulting in Riven only providing the show/movie name to Prowlarr indexers even if they're able to search by year/season/episode.

This commit fixes the issue by removing the 0-slice from the list comprehension.

## PR info

- No tests are included; this is fixing an issue with scrapers, for which there aren't any tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of movie and TV search capabilities in the Prowlarr integration.
  
- **Style**
	- Enhanced code formatting with a minor adjustment for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->