### PR TITLE
fix: remove catalog configuration from Mediafusion settings and scraper

### DIFF
--- a/src/program/services/scrapers/mediafusion.py
+++ b/src/program/services/scrapers/mediafusion.py
@@ -56,9 +56,6 @@ class Mediafusion:
         if not isinstance(self.settings.ratelimit, bool):
             logger.error("Mediafusion ratelimit must be a valid boolean.")
             return False
-        if not self.settings.catalogs:
-            logger.error("Configure at least one Mediafusion catalog.")
-            return False
 
         if self.app_settings.downloaders.real_debrid.enabled:
             self.api_key = self.app_settings.downloaders.real_debrid.api_key
@@ -76,7 +73,6 @@ class Mediafusion:
                 "tk": self.api_key,
                 "ewc": False
             },
-            "sc": self.settings.catalogs,
             "sr": ["4k", "2160p", "1440p", "1080p", "720p", "480p", None],
             "ec": False,
             "eim": False,

--- a/src/program/settings/models.py
+++ b/src/program/settings/models.py
@@ -229,11 +229,6 @@ class MediafusionConfig(Observable):
     url: str = "https://mediafusion.elfhosted.com"
     timeout: int = 30
     ratelimit: bool = True
-    catalogs: List[str] = [
-        "prowlarr_streams",
-        "torrentio_streams",
-        "zilean_dmm_streams"
-    ]
 
 class OrionoidConfig(Observable):
     enabled: bool = False


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:

Closes #918 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in the Mediafusion configuration by removing the mandatory catalogs requirement.
  
- **Bug Fixes**
	- Improved payload construction by excluding the catalogs key from the encryption endpoint.

- **Refactor**
	- Simplified the MediafusionConfig class by removing the catalogs attribute.
	- Marked the ratelimit attribute as deprecated across multiple configuration classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->