### PR TITLE
feat: convert rclone_path setting to src_paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ poetry run python backend/main.py
 
 ### Symlinking settings
 
-`rclone_path` should point to your rclone mount that has your torrents on your host.
+`src_paths` should be a list of paths to directories that contain your media files.
 
-`library_path` should point to the location of the mount in plex container
+`library_path` should point to the location where symlinks will be created (this is the path you'll add to Plex/Jellyfin/Emby)
 
 ```json
     "symlink": {
-        "rclone_path": "/mnt/zurg",
+        "src_paths": ["/mnt/zurg", "/mnt/other_media"],
         "library_path": "/mnt/library"
     }
 ```
@@ -183,7 +183,7 @@ Ensure you have the following installed on your system:
 
     ```sh
     pip install poetry
-    poetry install
+    poetry install --no-root
     ```
 
 3. **Install Frontend Dependencies:**

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,9 +9,9 @@ services:
     network_mode: host
     tty: true
     environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=UTC
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-UTC}
       - ORIGIN=${RIVEN_ORIGIN:-http://localhost:8080}
       - RIVEN_FORCE_ENV=true
       - RIVEN_DATABASE_HOST=sqlite:////riven/data/media.db

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -5,7 +5,7 @@
 
 # Zurg & Rclone will have to be supplied as well and visible to Riven as well as Plex.
 # Rclone should be mounted to: /mnt/zurg (optional directory)
-# You will need to set the rclone_path in riven to use the `/mnt/zurg/__all__` dir though
+# You will need to set the src_paths in riven to use the `/mnt/zurg/__all__` dir though
 # so that Riven can see all the torrents from their parent directory.
 
 services:
@@ -39,7 +39,7 @@ services:
             - PGID=1000
             - TZ=Etc/UTC
             - RIVEN_FORCE_ENV=true # forces the use of env vars to be always used!
-            - RIVEN_SYMLINK_RCLONE_PATH=/mnt/zurg/__all__ # Set this to your rclone's mount `__all__` dir if using Zurg
+            - RIVEN_SYMLINK_SRC_PATHS='["/mnt/zurg/__all__"]' # Set this to your source directories (JSON array)
             - RIVEN_SYMLINK_LIBRARY_PATH=/mnt/library # This is the path that symlinks will be placed in
             - RIVEN_DATABASE_HOST=postgresql+psycopg2://postgres:postgres@riven-db/riven
             - RIVEN_DOWNLOADERS_REAL_DEBRID_ENABLED=true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,7 +59,7 @@ else
     USER_HOME="/home/$USERNAME"
     mkdir -p "$USER_HOME"
     chown -R "$PUID:$PGID" "$USER_HOME"
-    chown -R "$PUID:$PGID" /riven/data
+    chown -R "$PUID:$PGID" /riven
 fi
 
 umask 002

--- a/makefile
+++ b/makefile
@@ -1,5 +1,8 @@
 .PHONY: help install run start start-dev stop restart logs logs-dev shell build push push-dev clean format check lint sort test coverage pr-ready
 
+PUID ?= $(shell id -u)
+PGID ?= $(shell id -g)
+
 # Detect operating system
 ifeq ($(OS),Windows_NT)
     # For Windows
@@ -31,13 +34,17 @@ help:
 	@echo "-------------------------------------------------------------------------"
 # Docker related commands
 
-start: stop
-	@docker compose -f docker-compose.yml up --build -d --force-recreate --remove-orphans
-	@docker compose -f docker-compose.yml logs -f
+start: stop .env
+	@docker compose -f docker-compose.yml --env-file .env up --build -d --force-recreate --remove-orphans
+	@docker compose -f docker-compose.yml --env-file .env logs -f
 
-start-dev: stop-dev
-	@docker compose -f docker-compose-dev.yml up --build -d --force-recreate --remove-orphans
-	@docker compose -f docker-compose-dev.yml logs -f
+start-dev: stop-dev .env
+	@docker compose -f docker-compose-dev.yml --env-file .env up --build -d --force-recreate --remove-orphans
+	@docker compose -f docker-compose-dev.yml --env-file .env logs -f
+
+.env:
+	@echo "PUID=$(PUID)" > $@
+	@echo "PGID=$(PGID)" >> $@
 
 stop:
 	@docker compose -f docker-compose.yml down

--- a/src/program/db/db_functions.py
+++ b/src/program/db/db_functions.py
@@ -629,5 +629,5 @@ if reset is not None and reset.lower() in ["true","1"]:
 
 # Repair Symlinks
 if os.getenv("REPAIR_SYMLINKS", None) is not None and os.getenv("REPAIR_SYMLINKS").lower() in ["true","1"]:
-    fix_broken_symlinks(settings_manager.settings.symlink.library_path, settings_manager.settings.symlink.rclone_path)
+    fix_broken_symlinks(settings_manager.settings.symlink.library_path, settings_manager.settings.symlink.src_paths)
     exit(0)

--- a/src/program/program.py
+++ b/src/program/program.py
@@ -224,7 +224,7 @@ class Program(threading.Thread):
         if settings_manager.settings.symlink.repair_symlinks:
             scheduled_functions[fix_broken_symlinks] = {
                 "interval": 60 * 60 * settings_manager.settings.symlink.repair_interval,
-                "args": [settings_manager.settings.symlink.library_path, settings_manager.settings.symlink.rclone_path]
+                "args": [settings_manager.settings.symlink.library_path, settings_manager.settings.symlink.src_paths]
             }
             # logger.warning("Symlink repair is disabled, this will be re-enabled in the future.")
 

--- a/src/program/settings/models.py
+++ b/src/program/settings/models.py
@@ -65,7 +65,7 @@ class DownloadersModel(Observable):
 
 
 class SymlinkModel(Observable):
-    rclone_path: Path = Path()
+    src_paths: List[Path] = []
     library_path: Path = Path()
     separate_anime_dirs: bool = False
     repair_symlinks: bool = False

--- a/src/program/utils/cli.py
+++ b/src/program/utils/cli.py
@@ -61,7 +61,7 @@ def handle_args():
         exit(0)
 
     if args.fix_symlinks:
-        fix_broken_symlinks(settings_manager.settings.symlink.library_path, settings_manager.settings.symlink.rclone_path)
+        fix_broken_symlinks(settings_manager.settings.symlink.library_path, settings_manager.settings.symlink.src_paths)
         exit(0)
 
     return args

--- a/src/routers/secure/default.py
+++ b/src/routers/secure/default.py
@@ -211,11 +211,11 @@ class MountResponse(BaseModel):
     files: dict[str, str]
 
 @router.get("/mount", operation_id="mount")
-async def get_rclone_files() -> MountResponse:
-    """Get all files in the rclone mount."""
+async def get_source_files() -> MountResponse:
+    """Get all files in the source paths."""
     import os
 
-    rclone_dir = settings_manager.settings.symlink.rclone_path
+    src_paths = settings_manager.settings.symlink.src_paths
     file_map = {}
 
     def scan_dir(path):
@@ -226,7 +226,10 @@ async def get_rclone_files() -> MountResponse:
                 elif entry.is_dir():
                     scan_dir(entry.path)
 
-    scan_dir(rclone_dir)  # dict of `filename: filepath``
+    # Scan all source paths
+    for src_path in src_paths:
+        scan_dir(src_path)  # dict of `filename: filepath``
+    
     return MountResponse(files=file_map)
 
 

--- a/src/routers/secure/items.py
+++ b/src/routers/secure/items.py
@@ -384,7 +384,7 @@ class RepairSymlinksResponse(BaseModel):
 )
 async def repair_symlinks(request: Request, directory: Optional[str] = None) -> RepairSymlinksResponse:
     library_path = settings_manager.settings.symlink.library_path
-    rclone_path = settings_manager.settings.symlink.rclone_path
+    src_paths = settings_manager.settings.symlink.src_paths
 
     if directory:
         specific_directory = os.path.join(library_path, directory)
@@ -393,7 +393,7 @@ async def repair_symlinks(request: Request, directory: Optional[str] = None) -> 
     else:
         specific_directory = None
 
-    fix_broken_symlinks(library_path, rclone_path, specific_directory=specific_directory)
+    fix_broken_symlinks(library_path, src_paths, specific_directory=specific_directory)
 
     return {"message": "Symlink repair process completed."}
 


### PR DESCRIPTION
# Pull Request Check List

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:

`rclone_path` assumes two things:

1) it is an rclone path. From what I can tell it doesn't have to be. it could just be a dirty directory of downloads. For me it will be rclone mounted <something not zurg>
2) There is only one source. I have a case for multiple sources


## Usecase

I have a bunch of files on RealDebrid
I have a bunch of files in premiumize.me

I could move the files to one but that sucks and assumes I could do so.

I don't use zurg for the premiumize mount because it's not supported and also the webdav provided by PM works great by itself. 

## Change

I have changed `rclone_path: str` to `src_paths: list[str]` so that I can map many sources to one unified library folder.

I ran this locally but some errors came up in tests that looked unrelated. As far as I can tell this is good, but I'm open to feedback/review.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying multiple source directories for media files instead of a single source path.

- **Documentation**
  - Updated documentation to clarify configuration changes, including examples and setup instructions.

- **Bug Fixes**
  - Improved environment variable handling in Docker and Makefile to allow for dynamic user and group IDs.

- **Refactor**
  - Updated internal logic and endpoints to generalize from a single source path to multiple source paths for symlink operations.

- **Tests**
  - Enhanced tests to cover scenarios with multiple source directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->