### PR TITLE
feat: set the media type when performing search

### DIFF
--- a/src/program/apis/trakt_api.py
+++ b/src/program/apis/trakt_api.py
@@ -197,6 +197,9 @@ class TraktAPI:
     def create_item_from_imdb_id(self, imdb_id: str, type: str = None) -> Optional[MediaItem]:
         """Wrapper for trakt.tv API search method."""
         url = f"{self.BASE_URL}/search/imdb/{imdb_id}?extended=full"
+        if type:
+            url+=f"&type={type}"
+            
         try:
             response = self.request_handler.execute(HttpMethod.GET, url, timeout=30)
         except TraktAPIError as e:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #1109

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:
Append the `type` to the query, while testing the API manually I've found that if you make an extended request without including the media type it gives a 403. 

Making the following call: `https://api.trakt.tv/search/imdb/tt0848228?extended=full`, fails with a 403
But, this `https://api.trakt.tv/search/imdb/tt0848228?type=movie&extended=full` does not fail and returns the full response. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved API integration to support filtering search results by media type when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->