### PR TITLE
fix(updater): after refactor updater keys went missing

### DIFF
--- a/src/program/services/updaters/base.py
+++ b/src/program/services/updaters/base.py
@@ -21,16 +21,14 @@ class BaseUpdater(ABC):
         Args:
             service_name: Name of the service (e.g., "Plex", "Emby", "Jellyfin")
         """
-        self.service_name = service_name
+        self.key = service_name
         self.initialized = False
 
     def _initialize(self):
         """Initialize the updater by validating configuration."""
         if self.validate():
             self.initialized = True
-            logger.success(f"{self.service_name} updater initialized")
-        else:
-            logger.warning(f"{self.service_name} updater not initialized")
+            logger.success(f"{self.__class__.__name__} updater initialized")
 
     @abstractmethod
     def validate(self) -> bool:

--- a/src/program/services/updaters/emby.py
+++ b/src/program/services/updaters/emby.py
@@ -10,7 +10,7 @@ class EmbyUpdater(BaseUpdater):
     """Emby media server updater implementation"""
 
     def __init__(self):
-        super().__init__("Emby")
+        super().__init__("emby")
         self.settings = settings_manager.settings.updaters.emby
         self.session = SmartSession(retries=3, backoff_factor=0.3)
         self._initialize()

--- a/src/program/services/updaters/jellyfin.py
+++ b/src/program/services/updaters/jellyfin.py
@@ -10,7 +10,7 @@ class JellyfinUpdater(BaseUpdater):
     """Jellyfin media server updater implementation"""
 
     def __init__(self):
-        super().__init__("Jellyfin")
+        super().__init__("jellyfin")
         self.settings = settings_manager.settings.updaters.jellyfin
         self.session = SmartSession(retries=3, backoff_factor=0.3)
         self._initialize()

--- a/src/program/services/updaters/plex.py
+++ b/src/program/services/updaters/plex.py
@@ -15,7 +15,7 @@ from program.settings.manager import settings_manager
 
 class PlexUpdater(BaseUpdater):
     def __init__(self):
-        super().__init__("Plex")
+        super().__init__("plexupdater")
         self.library_path = settings_manager.settings.updaters.library_path
         self.settings = settings_manager.settings.updaters.plex
         self.api = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized updater identifiers for Emby and Jellyfin to lowercase; updated Plex identifier for consistency.
  * Aligned internal naming for updaters without changing public behavior or interfaces.

* **Chores**
  * Updated initialization logs to reference class names for clearer messages.
  * Removed a fallback warning on failed initialization to streamline log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->