### PR TITLE
feat: metadata based libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,66 @@ sudo fusermount -uz /path/to/riven/mount || sudo umount -l /path/to/riven/mount
   - LRU (default): Strictly enforces the configured size caps by evicting least‑recently‑used blocks when space is needed.
   - TTL: First removes entries that have been idle longer than `ttl_seconds` (sliding expiration). If the cache still exceeds the configured size cap after TTL pruning, it additionally trims oldest entries (LRU) until usage is within the limit.
 
+### Library Profiles
+
+Library profiles allow you to organize media into different virtual libraries based on metadata filters. Media matching a profile appears at both the base path (e.g., `/movies/Title/`) and the profile path (e.g., `/kids/movies/Title/`).
+
+**Configuration**: Edit `library_profiles` in `settings.json` under the `filesystem` section. Multiple example profiles are provided (disabled by default) - enable them or create your own.
+
+**Available Filters**:
+
+| Filter | Type | Description | Example |
+|--------|------|-------------|---------|
+| `content_types` | List[str] | Media types to include (`movie`, `show`) | `["movie", "show"]` |
+| `genres` | List[str] | Include if ANY genre matches (OR logic) | `["animation", "family"]` |
+| `exclude_genres` | List[str] | Exclude if ANY genre matches | `["horror"]` |
+| `min_year` | int | Minimum release year | `2020` |
+| `max_year` | int | Maximum release year | `1999` |
+| `min_rating` | float | Minimum rating (0-10 scale) | `7.5` |
+| `max_rating` | float | Maximum rating (0-10 scale) | `9.0` |
+| `is_anime` | bool | Filter by anime flag (true/false) | `true` |
+| `networks` | List[str] | TV networks (OR logic) | `["HBO", "HBO Max"]` |
+| `countries` | List[str] | Countries of origin (ISO codes, OR logic) | `["GB", "UK"]` |
+| `languages` | List[str] | Original languages (ISO 639-1 codes, OR logic) | `["en", "ja"]` |
+| `content_ratings` | List[str] | Allowed content ratings | `["G", "PG", "TV-Y"]` |
+
+**Content Ratings Reference**:
+- **US Movies**: `G`, `PG`, `PG-13`, `R`, `NC-17`, `NR` (Not Rated), `Unrated`
+- **US TV**: `TV-Y`, `TV-Y7`, `TV-G`, `TV-PG`, `TV-14`, `TV-MA`
+
+**Example Profile**:
+```json
+{
+  "filesystem": {
+    "library_profiles": {
+      "kids": {
+        "name": "Kids & Family Content",
+        "library_path": "/kids",
+        "enabled": true,
+        "filter_rules": {
+          "content_types": ["movie", "show"],
+          "genres": ["animation", "family"],
+          "content_ratings": ["G", "PG", "TV-Y", "TV-G"],
+          "max_rating": 7.5
+        }
+      }
+    }
+  }
+}
+```
+
+**How It Works**:
+1. Media is downloaded and metadata is evaluated against all enabled profiles
+2. Matching media appears at base path + all matching profile paths
+3. Media servers (Plex/Jellyfin/Emby) see the content in all applicable libraries
+4. Filters use AND logic between different filter types, OR logic within list filters
+
+**Notes**:
+- Remove any filter you don't want to use
+- All filters must match for a profile to apply (AND logic)
+- List filters (genres, networks, etc.) match if ANY value matches (OR logic)
+- Shows/Seasons inherit metadata from parent for filtering purposes
+
 ## Development
 
 Welcome to the development section! Here, you'll find all the necessary steps to set up your development environment and start contributing to the project.

--- a/src/alembic/versions/20251009_1200_a1b2c3d4e5f7_combined_library_profiles.py
+++ b/src/alembic/versions/20251009_1200_a1b2c3d4e5f7_combined_library_profiles.py
@@ -1,0 +1,69 @@
+"""combined_library_profiles
+
+Revision ID: a1b2c3d4e5f7
+Revises: f7ea12c9d1ab
+Create Date: 2025-10-09 12:00:00.000000
+
+This migration combines:
+1. Adding rating and content_rating fields to MediaItem
+2. Adding library_profiles field to MediaEntry
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f7'
+down_revision: Union[str, None] = 'f7ea12c9d1ab'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    1. Add rating and content_rating to MediaItem
+    2. Add library_profiles to MediaEntry
+    3. Trigger re-indexing by clearing indexed_at for all items
+    """
+    
+    # Step 1: Add rating and content_rating fields to MediaItem
+    with op.batch_alter_table('MediaItem', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('rating', sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column('content_rating', sa.String(), nullable=True))
+        batch_op.create_index('ix_mediaitem_content_rating', ['content_rating'], unique=False)
+        batch_op.create_index('ix_mediaitem_rating', ['rating'], unique=False)
+
+    # Step 2: Add library_profiles field to MediaEntry
+    with op.batch_alter_table('MediaEntry', schema=None) as batch_op:
+        batch_op.add_column(sa.Column(
+            'library_profiles',
+            sa.JSON(),
+            nullable=True,
+            comment='List of library profile keys this entry matches (from settings.json)'
+        ))
+
+    print("Migration complete: Added rating, content_rating, and library_profiles fields.")
+
+
+def downgrade() -> None:
+    """
+    Reverse the migration:
+    1. Remove library_profiles from MediaEntry
+    2. Remove rating and content_rating from MediaItem
+    """
+    
+    # Step 1: Remove library_profiles from MediaEntry
+    with op.batch_alter_table('MediaEntry', schema=None) as batch_op:
+        batch_op.drop_column('library_profiles')
+
+    # Step 2: Remove rating and content_rating from MediaItem
+    with op.batch_alter_table('MediaItem', schema=None) as batch_op:
+        batch_op.drop_index('ix_mediaitem_rating')
+        batch_op.drop_index('ix_mediaitem_content_rating')
+        batch_op.drop_column('content_rating')
+        batch_op.drop_column('rating')
+

--- a/src/program/services/filesystem/vfs/cache.py
+++ b/src/program/services/filesystem/vfs/cache.py
@@ -73,6 +73,7 @@ class Cache:
         self._total_bytes = 0
         self._lock = threading.RLock()
         self._metrics = _Metrics()
+        self._last_log = 0.0  # Initialize last log timestamp
         try:
             os.makedirs(self.cfg.cache_dir, exist_ok=True)
         except Exception as e:

--- a/src/program/services/filesystem/vfs/db.py
+++ b/src/program/services/filesystem/vfs/db.py
@@ -42,28 +42,19 @@ class VFSDatabase:
         return path
 
     def _ensure_default_directories(self) -> None:
-        """Ensure default directories exist in the VFS for library structure"""
-        default_dirs = ['/movies', '/shows', '/anime_movies', '/anime_shows']
+        """
+        Ensure default directories exist in the VFS for library structure.
 
-        with self.SessionLocal.begin() as s:
-            for dir_path in default_dirs:
-                # Check if directory already exists
-                existing = s.query(FilesystemEntry.id).filter_by(
-                    path=dir_path
-                ).first()
+        Note: Directories are created automatically by the VFS based on file paths.
+        This method is kept for backward compatibility with existing code that may
+        expect these directories to exist in the database.
 
-                if not existing:
-                    # Create directory entry
-                    dir_entry = MediaEntry.create_virtual_entry(
-                        path=dir_path,
-                        download_url=None,
-                        provider=None,
-                        provider_download_id=None,
-                        file_size=0,
-                        original_filename=None
-                    )
-                    dir_entry.is_directory = True
-                    s.add(dir_entry)
+        In practice, the VFS will create virtual directories on-the-fly when listing
+        parent directories of files, so explicit directory creation is not required.
+        """
+        # Legacy directories for backward compatibility with existing data
+        # These will be automatically created as virtual directories when files are added
+        pass
 
     # --- Queries ---
     def get_entry(self, path: str) -> Optional[Dict]:

--- a/src/program/services/filesystem/vfs/rivenvfs.py
+++ b/src/program/services/filesystem/vfs/rivenvfs.py
@@ -211,6 +211,93 @@ MEDIA_SCANNERS = [
 
 
 @dataclass
+class VFSNode:
+    """
+    Represents a node (file or directory) in the VFS tree.
+
+    This is the core data structure for the in-memory VFS tree, providing
+    O(1) lookups and eliminating the need for path resolution.
+
+    Attributes:
+        name: Name of this node (e.g., "Frozen.mkv" or "movies")
+        is_directory: True if this is a directory, False if it's a file
+        base_path: Path in database for files (e.g., "/movies/Frozen.mkv")
+                   For profile paths, this points to the canonical base path.
+                   For directories, this is None.
+        inode: FUSE inode number assigned to this node
+        children: Dict of child name -> VFSNode (only for directories)
+        parent: Reference to parent VFSNode (None for root)
+
+        # Cached file metadata (for files only, eliminates DB queries in getattr)
+        file_size: File size in bytes (None for directories)
+        created_at: Creation timestamp as ISO string (None for directories)
+        updated_at: Modification timestamp as ISO string (None for directories)
+        entry_type: Entry type ("media" or "subtitle", None for directories)
+    """
+    name: str
+    is_directory: bool
+    base_path: Optional[str] = None
+    inode: Optional[int] = None
+    parent: Optional['VFSNode'] = None
+
+    # Cached metadata for files (eliminates database queries)
+    file_size: Optional[int] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    entry_type: Optional[str] = None
+
+    def __post_init__(self):
+        """Initialize children dict after dataclass init."""
+        if not hasattr(self, '_children'):
+            self._children: Dict[str, VFSNode] = {}
+
+    @property
+    def children(self) -> Dict[str, 'VFSNode']:
+        """Get children dict."""
+        if not hasattr(self, '_children'):
+            self._children = {}
+        return self._children
+
+    def get_full_path(self) -> str:
+        """Get the full VFS path for this node by walking up to root."""
+        if self.parent is None:
+            return "/"
+
+        parts = []
+        current = self
+        while current.parent is not None:
+            parts.append(current.name)
+            current = current.parent
+
+        if not parts:
+            return "/"
+
+        return "/" + "/".join(reversed(parts))
+
+    def add_child(self, child: 'VFSNode') -> None:
+        """Add a child node to this directory."""
+        if not self.is_directory:
+            raise ValueError(f"Cannot add child to non-directory node: {self.name}")
+
+        child.parent = self
+        self.children[child.name] = child
+
+    def remove_child(self, name: str) -> Optional['VFSNode']:
+        """Remove and return a child node by name."""
+        child = self.children.pop(name, None)
+        if child:
+            child.parent = None
+        return child
+
+    def get_child(self, name: str) -> Optional['VFSNode']:
+        """Get a child node by name."""
+        return self.children.get(name)
+
+    def __repr__(self) -> str:
+        return f"VFSNode(name={self.name!r}, is_dir={self.is_directory}, inode={self.inode}, children={len(self.children)})"
+
+
+@dataclass
 class PrefetchChunk:
     """Represents a chunk to be prefetched with priority information."""
     path: str
@@ -405,17 +492,19 @@ class RivenVFS(pyfuse3.Operations):
         self.downloader = downloader
         self.db = VFSDatabase(downloader=downloader)
 
-        # Core path <-> inode mapping for FUSE operations
-        self._path_to_inode: Dict[str, int] = {"/": pyfuse3.ROOT_INODE}
-        self._inode_to_path: Dict[int, str] = {pyfuse3.ROOT_INODE: "/"}
+        # VFS Tree: In-memory tree structure for O(1) path lookups
+        # This replaces _path_to_inode, _path_aliases, and _dir_tree
+        self._root = VFSNode(name="", is_directory=True, inode=pyfuse3.ROOT_INODE)
+        self._inode_to_node: Dict[int, VFSNode] = {pyfuse3.ROOT_INODE: self._root}
         self._next_inode = pyfuse3.ROOT_INODE + 1
+
+        # Tree lock to prevent race conditions between FUSE operations and tree rebuilds
+        # pyfuse3 runs FUSE operations in threads, so we use threading.RLock()
+        self._tree_lock = threading.RLock()
 
         # URL cache for provider links with automatic expiration
         self._url_cache: Dict[str, Dict[str, object]] = {}
         self.url_cache_ttl = 15 * 60  # 15 minutes
-        # Entry info cache to reduce redundant DB lookups in FUSE ops
-        self._entry_cache: Dict[str, tuple[Optional[Dict], float]] = {}
-        self._entry_cache_ttl = 30.0  # seconds
 
         # Shared HTTP client (pycurl + CurlShare) for connection reuse
         self.http = ProviderHTTP()
@@ -476,7 +565,6 @@ class RivenVFS(pyfuse3.Operations):
         pyfuse3.init(self, self._mountpoint, fuse_options)
         self._mounted = True
 
-        import threading
         def _fuse_runner():
             async def _async_main():
                 # capture Trio token so we can call into the loop from other threads
@@ -496,6 +584,318 @@ class RivenVFS(pyfuse3.Operations):
         self._thread.start()
 
         log.log("VFS", f"RivenVFS mounted at {self._mountpoint}")
+
+        # Synchronize library profiles with VFS structure
+        self.sync_library_profiles()
+
+    # ========== VFS Tree Helper Methods ==========
+
+    def _get_node_by_path(self, path: str) -> Optional[VFSNode]:
+        """
+        Get a VFSNode by walking the tree from root.
+
+        This is O(depth) instead of O(n) like the old path iteration approach.
+
+        Args:
+            path: NORMALIZED VFS path (e.g., "/movies/Frozen.mkv")
+                  Caller must normalize before calling this method.
+
+        Returns:
+            VFSNode if found, None otherwise
+        """
+        if path == "/":
+            return self._root
+
+        # Split path and walk tree
+        parts = [p for p in path.split("/") if p]
+        current = self._root
+
+        for part in parts:
+            current = current.get_child(part)
+            if current is None:
+                return None
+
+        return current
+
+    def _get_or_create_node(self, path: str, is_directory: bool, base_path: Optional[str] = None) -> VFSNode:
+        """
+        Get or create a node at the given path, creating parent directories as needed.
+
+        Args:
+            path: NORMALIZED VFS path (caller must normalize)
+            is_directory: Whether this is a directory
+            base_path: Base path in database (for files)
+
+        Returns:
+            The VFSNode at the path
+        """
+        if path == "/":
+            return self._root
+
+        # Split path and walk/create tree
+        parts = [p for p in path.split("/") if p]
+        current = self._root
+
+        for i, part in enumerate(parts):
+            child = current.get_child(part)
+
+            if child is None:
+                # Create the node
+                is_last = (i == len(parts) - 1)
+
+                if is_last:
+                    # This is the target node
+                    child = VFSNode(
+                        name=part,
+                        is_directory=is_directory,
+                        base_path=base_path,
+                        inode=self._assign_inode()
+                    )
+                else:
+                    # This is a parent directory
+                    child = VFSNode(
+                        name=part,
+                        is_directory=True,
+                        inode=self._assign_inode()
+                    )
+
+                current.add_child(child)
+                self._inode_to_node[child.inode] = child
+
+            current = child
+
+        return current
+
+    def _remove_node(self, path: str) -> bool:
+        """
+        Remove a node from the tree.
+
+        Args:
+            path: NORMALIZED VFS path to remove (caller must normalize)
+
+        Returns:
+            True if removed, False if not found
+        """
+        if path == "/":
+            return False  # Can't remove root
+
+        node = self._get_node_by_path(path)
+        if node is None:
+            return False
+
+        # Remove from parent
+        if node.parent:
+            node.parent.remove_child(node.name)
+
+        # Remove from inode map
+        if node.inode:
+            self._inode_to_node.pop(node.inode, None)
+
+        # Recursively remove all children from inode map
+        self._remove_node_recursive(node)
+
+        return True
+
+    def _remove_node_recursive(self, node: VFSNode) -> None:
+        """Recursively remove all children from inode map."""
+        for child in list(node.children.values()):
+            if child.inode:
+                self._inode_to_node.pop(child.inode, None)
+            self._remove_node_recursive(child)
+
+    def _assign_inode(self) -> int:
+        """Assign a new inode number."""
+        inode = self._next_inode
+        self._next_inode += 1
+        return inode
+
+    def _get_parent_inodes(self, node: VFSNode) -> List[int]:
+        """
+        Get all parent inodes from node up to root.
+
+        This is useful for collecting parent directories that need cache invalidation.
+
+        Args:
+            node: Starting node
+
+        Returns:
+            List of parent inodes (excluding root)
+        """
+        inodes = []
+        current = node.parent
+        while current and current != self._root:
+            if current.inode:
+                inodes.append(current.inode)
+            current = current.parent
+        return inodes
+
+    # ========== End VFS Tree Helper Methods ==========
+
+    def sync_library_profiles(self) -> None:
+        """
+        Synchronize VFS with library profiles from settings.
+
+        This method:
+        1. Re-matches all MediaEntry items against current library profiles
+        2. Builds the set of current VFS paths based on matched profiles
+        3. Removes stale paths (paths that no longer exist)
+        4. Adds new paths (paths that didn't exist before)
+
+        Note: Uses incremental updates to preserve kernel inode cache consistency.
+        Directories are created automatically by the VFS based on file paths.
+
+        Called automatically:
+        - During RivenVFS initialization
+        - When settings change (via FilesystemService)
+        """
+        from program.media.media_entry import MediaEntry
+        from program.services.library_profile_matcher import LibraryProfileMatcher
+
+        log.log("VFS", "Synchronizing library profiles with VFS")
+
+        matcher = LibraryProfileMatcher()
+
+        # Step 1: Re-match all entries against current library profiles and build metadata map
+        from program.db.db import db as db_module
+        with db_module.Session() as session:
+            entries = session.query(MediaEntry).filter(
+                MediaEntry.is_directory == False
+            ).all()
+
+            current_paths = set()
+            path_to_base = {}  # Build inside session to avoid detached instance errors
+            path_to_metadata = {}  # Cache metadata for each path
+            rematched_count = 0
+
+            for entry in entries:
+                # Get the MediaItem for this entry to re-match profiles
+                item = entry.media_item
+                if not item:
+                    log.warning(f"MediaEntry {entry.id} has no associated MediaItem, skipping")
+                    continue
+
+                # For episodes/seasons, ensure metadata is propagated from parent show
+                if item.type in ["episode", "season"]:
+                    from program.media.item import Show
+                    # Get the parent show and propagate attributes
+                    if item.type == "episode" and item.parent and item.parent.parent:
+                        show = item.parent.parent
+                        if isinstance(show, Show):
+                            show.propagate_attributes_to_childs()
+                    elif item.type == "season" and item.parent:
+                        show = item.parent
+                        if isinstance(show, Show):
+                            show.propagate_attributes_to_childs()
+
+                # Re-match library profiles based on current settings
+                new_profiles = matcher.get_matching_profiles(item)
+                old_profiles = entry.library_profiles or []
+
+                # Update if profiles changed
+                if set(new_profiles) != set(old_profiles):
+                    entry.library_profiles = new_profiles
+                    rematched_count += 1
+
+                # Get all current VFS paths for this entry
+                vfs_paths = entry.get_library_paths()
+                current_paths.update(vfs_paths)
+
+                # Build path to base path mapping and metadata cache (inside session)
+                if vfs_paths:
+                    base_path = vfs_paths[0]  # First path is always base path
+
+                    # Extract metadata from entry (use correct attribute names!)
+                    metadata = {
+                        'file_size': entry.file_size,
+                        'created_at': entry.created_at.isoformat() if entry.created_at else None,
+                        'updated_at': entry.updated_at.isoformat() if entry.updated_at else None,
+                        'entry_type': entry.entry_type
+                    }
+
+                    for vfs_path in vfs_paths:
+                        path_to_base[vfs_path] = base_path
+                        path_to_metadata[vfs_path] = metadata
+
+            session.commit()
+            log.debug(f"Re-matched {rematched_count} entries with updated profiles")
+
+        # Step 2: Rebuild VFS tree from current paths
+        # Build new tree outside the lock to minimize critical section
+        new_root = VFSNode(name="", is_directory=True, inode=pyfuse3.ROOT_INODE)
+        new_inode_to_node: Dict[int, VFSNode] = {pyfuse3.ROOT_INODE: new_root}
+        new_next_inode = self._next_inode  # Preserve inode counter
+
+        added_count = 0
+        directories_to_invalidate = set()
+
+        # Build the new tree (temporarily use instance variables for _get_or_create_node to work)
+        # This is safe because sync_library_profiles is only called from one thread at a time
+        saved_root = self._root
+        saved_inode_to_node = self._inode_to_node
+        saved_next_inode = self._next_inode
+
+        self._root = new_root
+        self._inode_to_node = new_inode_to_node
+        self._next_inode = new_next_inode
+
+        for vfs_path in current_paths:
+            # Get base path and metadata for this VFS path
+            base_path = path_to_base.get(vfs_path, vfs_path)
+            metadata = path_to_metadata.get(vfs_path, {})
+
+            # Create node in tree (creates parent directories automatically)
+            node = self._get_or_create_node(
+                path=vfs_path,
+                is_directory=False,  # We know these are files
+                base_path=base_path
+            )
+
+            # Populate cached metadata in the node (eliminates DB queries in getattr!)
+            node.file_size = metadata.get('file_size')
+            node.created_at = metadata.get('created_at')
+            node.updated_at = metadata.get('updated_at')
+            node.entry_type = metadata.get('entry_type')
+
+            added_count += 1
+
+            # Collect parent directories for invalidation
+            parent_node = node.parent
+            while parent_node and parent_node != new_root:
+                directories_to_invalidate.add(parent_node.get_full_path())
+                parent_node = parent_node.parent
+
+        # Capture the new tree state
+        new_next_inode = self._next_inode
+
+        # Atomic swap: Replace old tree with new tree under lock
+        with self._tree_lock:
+            self._root = new_root
+            self._inode_to_node = new_inode_to_node
+            self._next_inode = new_next_inode
+
+        log.log("VFS",
+            f"Sync complete: rebuilt tree with {added_count} files, "
+            f"re-matched {rematched_count} entries"
+        )
+
+        # Step 3: Invalidate directory caches for changed directories
+        if added_count > 0:
+            try:
+                # Invalidate root directory
+                pyfuse3.invalidate_inode(pyfuse3.ROOT_INODE, attr_only=False)
+
+                # Invalidate all affected parent directories
+                for dir_path in directories_to_invalidate:
+                    node = self._get_node_by_path(dir_path)
+                    if node and node.inode:
+                        try:
+                            pyfuse3.invalidate_inode(node.inode, attr_only=False)
+                        except OSError:
+                            pass  # Ignore if kernel hasn't cached this inode yet
+
+                log.debug(f"Invalidated root + {len(directories_to_invalidate)} directory caches after sync")
+            except Exception as e:
+                log.trace(f"Could not invalidate directory caches: {e}")
 
     def close(self) -> None:
         """Clean up and unmount the filesystem."""
@@ -616,24 +1016,29 @@ class RivenVFS(pyfuse3.Operations):
         # Add file to database (creates parent directories automatically)
         self.db.add_file(path, url, int(size or 0), provider=provider,
                          provider_download_id=provider_download_id)
-        # Invalidate entry cache for this path and its parent
-        self._entry_cache_invalidate_path(path)
 
+        # Create node in tree (creates parent directories automatically)
+        with self._tree_lock:
+            node = self._get_or_create_node(
+                path=path,
+                is_directory=False,
+                base_path=path  # For add_file, path is always the base path
+            )
 
-        # Assign inode for the new file
-        self._assign_inode(path)
+            # Populate metadata in node (so getattr doesn't need DB query)
+            from datetime import datetime, timezone
+            now = datetime.now(timezone.utc)
+            node.file_size = int(size or 0)
+            node.created_at = now.isoformat()
+            node.updated_at = now.isoformat()
+            node.entry_type = "media"  # add_file creates media entries
 
-        # Assign inodes for any newly created parent directories
-        parent = self._normalize_path(self._get_parent_path(path))
-        parent_inodes_to_invalidate = []
-        while parent != "/" and parent not in self._path_to_inode:
-            parent_ino = self._assign_inode(parent)
-            parent_inodes_to_invalidate.append(parent_ino)
-            parent = self._normalize_path(self._get_parent_path(parent))
+            # Get parent inodes for invalidation (must be done inside lock)
+            parent_inodes = self._get_parent_inodes(node)
 
         # Invalidate FUSE cache to ensure directory listings are updated
         # This is crucial for media players that cache directory structure
-        self._invalidate_directory_cache(path, parent_inodes_to_invalidate)
+        self._invalidate_directory_cache(path, parent_inodes)
 
         log.debug(f"Added virtual file: {path}")
         return True
@@ -645,35 +1050,76 @@ class RivenVFS(pyfuse3.Operations):
         This is useful when FilesystemEntry records already exist in the database
         but need to be made accessible via FUSE.
 
+        For library profile paths (e.g., /kids/movies/...), this method resolves them
+        to the base path (e.g., /movies/...) for database lookup, then creates a node
+        in the tree with the base_path reference.
+
         Args:
-            path: Virtual path of the existing file
+            path: Virtual path of the existing file (can be base path or profile path)
 
         Returns:
             True if file was registered successfully
         """
         path = self._normalize_path(path)
 
-        # Check if file exists in database
-        if not self.db.exists(path):
-            log.warning(f"Cannot register non-existent file: {path}")
+        with self._tree_lock:
+            # Get base path from node if it exists, otherwise resolve it
+            node = self._get_node_by_path(path)
+            if node:
+                base_path = node.base_path or path
+            else:
+                base_path = self._resolve_path(path)
+
+        # Check if base path exists in database and get metadata
+        entry_info = self.db.get_entry(base_path)
+        if not entry_info:
+            log.warning(f"Cannot register non-existent file: {path} (resolved: {base_path})")
             return False
 
-        # Assign inode for the file
-        self._assign_inode(path)
+        with self._tree_lock:
+            # Create node in tree (creates parent directories automatically)
+            # Note: This is called during sync, so the node might already exist
+            if not node:
+                node = self._get_or_create_node(
+                    path=path,
+                    is_directory=False,
+                    base_path=base_path
+                )
 
-        # Assign inodes for any parent directories that need them
-        parent = self._normalize_path(self._get_parent_path(path))
-        parent_inodes_to_invalidate = []
-        while parent != "/" and parent not in self._path_to_inode:
-            parent_ino = self._assign_inode(parent)
-            parent_inodes_to_invalidate.append(parent_ino)
-            parent = self._normalize_path(self._get_parent_path(parent))
+            # Populate metadata in node from database entry
+            node.file_size = entry_info.get("size", 0)
+            node.created_at = entry_info.get("created")
+            node.updated_at = entry_info.get("modified")
+            node.entry_type = entry_info.get("entry_type", "media")
+
+            # Get parent inodes for invalidation (must be done inside lock)
+            parent_inodes = self._get_parent_inodes(node)
 
         # Invalidate FUSE cache to ensure directory listings are updated
-        self._invalidate_directory_cache(path, parent_inodes_to_invalidate)
+        self._invalidate_directory_cache(path, parent_inodes)
 
-        log.debug(f"Registered existing file with FUSE: {path}")
         return True
+
+    def _resolve_path(self, path: str) -> str:
+        """
+        Resolve a path to its base path using the VFS tree.
+
+        If the path is a library profile path, returns the base path stored in the node.
+        Otherwise, returns the path as-is.
+
+        Args:
+            path: NORMALIZED path to resolve (caller must normalize)
+
+        Returns:
+            Resolved path (base path if it's a profile path, otherwise original path)
+        """
+        # Check if node exists and has base_path
+        node = self._get_node_by_path(path)
+        if node and node.base_path:
+            return node.base_path
+
+        # If not in tree, return as-is (shouldn't happen in normal operation)
+        return path
 
     def rename_file(self, old_path: str, new_path: str) -> bool:
         """
@@ -696,31 +1142,41 @@ class RivenVFS(pyfuse3.Operations):
             log.warning(f"Failed to rename file in database: {old_path} -> {new_path}")
             return False
 
-        # Invalidate entry cache for old and new paths
-        self._entry_cache_invalidate_path(old_path)
-        self._entry_cache_invalidate_path(new_path)
+        # Update VFS tree
+        with self._tree_lock:
+            # Get old node to preserve metadata
+            old_node = self._get_node_by_path(old_path)
+            old_metadata = None
+            if old_node:
+                # Save metadata before removing
+                old_metadata = {
+                    'file_size': old_node.file_size,
+                    'created_at': old_node.created_at,
+                    'updated_at': old_node.updated_at,
+                    'entry_type': old_node.entry_type
+                }
+                self._remove_node(old_path)
 
-        # Update FUSE layer
-        # Remove old inode mapping if it exists
-        if old_path in self._path_to_inode:
-            old_inode = self._path_to_inode[old_path]
-            del self._path_to_inode[old_path]
-            del self._inode_to_path[old_inode]
+            # Create new node
+            new_node = self._get_or_create_node(
+                path=new_path,
+                is_directory=False,
+                base_path=new_path  # For rename, new_path is the base path
+            )
 
-        # Assign inode for the new path
-        self._assign_inode(new_path)
+            # Restore metadata to new node
+            if old_metadata:
+                new_node.file_size = old_metadata['file_size']
+                new_node.created_at = old_metadata['created_at']
+                new_node.updated_at = old_metadata['updated_at']
+                new_node.entry_type = old_metadata['entry_type']
 
-        # Assign inodes for any parent directories that need them
-        parent = self._normalize_path(self._get_parent_path(new_path))
-        parent_inodes_to_invalidate = []
-        while parent != "/" and parent not in self._path_to_inode:
-            parent_ino = self._assign_inode(parent)
-            parent_inodes_to_invalidate.append(parent_ino)
-            parent = self._normalize_path(self._get_parent_path(parent))
+            # Get parent inodes for invalidation (must be done inside lock)
+            parent_inodes = self._get_parent_inodes(new_node)
 
         # Invalidate FUSE cache for both old and new locations
         self._invalidate_rename_cache(old_path, new_path, None)
-        self._invalidate_directory_cache(new_path, parent_inodes_to_invalidate)
+        self._invalidate_directory_cache(new_path, parent_inodes)
 
         log.debug(f"Renamed file: {old_path} -> {new_path}")
         return True
@@ -735,12 +1191,18 @@ class RivenVFS(pyfuse3.Operations):
         return self.db.exists(self._normalize_path(path))
 
     def get_file_info(self, path: str) -> Optional[Dict]:
-        """Get information about a virtual file."""
-        return self.db.get_entry(self._normalize_path(path))
+        """
+        Get information about a virtual file.
+
+        Resolves library profile paths to base paths for database lookup using alias map.
+        """
+        path = self._normalize_path(path)
+        resolved_path = self._resolve_path(path)
+        return self.db.get_entry(resolved_path)
 
     def list_directory(self, path: str) -> list[Dict]:
-        """List contents of a virtual directory."""
-        return self.db.list_directory(self._normalize_path(path))
+        """List contents of a virtual directory using VFS tree."""
+        return self._list_directory_cached(self._normalize_path(path))
     
     def get_opener_stats(self) -> Dict[str, Dict]:
         """Get statistics for each opener (process that opened files)."""
@@ -771,56 +1233,43 @@ class RivenVFS(pyfuse3.Operations):
             p = p / part
         return self._normalize_path(str(p))
 
-    def _get_entry_cached(self, path: str) -> Optional[Dict]:
-        """Cached wrapper around self.db.get_entry to reduce repeated queries."""
-        import time
-        path = self._normalize_path(path)
-        ent_ts = self._entry_cache.get(path)
-        now = time.time()
-        if ent_ts is not None:
-            ent, ts = ent_ts
-            try:
-                if now - float(ts) < float(self._entry_cache_ttl):
-                    return ent
-            except Exception:
-                pass
-        ent = self.db.get_entry(path)
-        self._entry_cache[path] = (ent, now)
-        return ent
-
     def _exists_cached(self, path: str) -> bool:
-        return self._get_entry_cached(path) is not None
+        """Check if path exists in VFS tree (no database query)."""
+        return self._get_node_by_path(path) is not None
 
     def _list_directory_cached(self, path: str) -> list[Dict]:
-        # Keep listing uncached for simplicity and freshness; can be cached if needed later
-        return self.db.list_directory(self._normalize_path(path))
+        """
+        List directory contents using VFS tree for O(1) lookups.
 
-    def _entry_cache_invalidate_path(self, path: str) -> None:
-        """Invalidate cached entry info for a path and its parent directory."""
-        try:
-            path = self._normalize_path(path)
-            self._entry_cache.pop(path, None)
-            parent = self._normalize_path(self._get_parent_path(path))
-            self._entry_cache.pop(parent, None)
-        except Exception:
-            pass
+        The VFS tree is built during sync_library_profiles() and provides
+        instant directory listings without any database queries.
 
-    def _assign_inode(self, path: str) -> int:
-        """Assign an inode number to a path."""
-        if path in self._path_to_inode:
-            return self._path_to_inode[path]
-        ino = self._next_inode
-        self._next_inode += 1
-        self._path_to_inode[path] = ino
-        self._inode_to_path[ino] = path
-        return ino
+        Args:
+            path: NORMALIZED VFS path (caller must normalize)
+        """
+        with self._tree_lock:
+            # Get node from tree
+            node = self._get_node_by_path(path)
+            if node is None or not node.is_directory:
+                return []
+
+            # Build result list from node's children - no database queries!
+            children = []
+            for name, child in node.children.items():
+                children.append({
+                    "name": name,
+                    "is_directory": child.is_directory
+                })
+
+            return children
 
     def _get_path_from_inode(self, inode: int) -> str:
-        """Get path from inode number."""
-        try:
-            return self._inode_to_path[inode]
-        except KeyError:
-            raise pyfuse3.FUSEError(errno.ENOENT)
+        """Get path from inode number using the VFS tree."""
+        with self._tree_lock:
+            node = self._inode_to_node.get(inode)
+            if node is None:
+                raise pyfuse3.FUSEError(errno.ENOENT)
+            return node.get_full_path()
 
     @staticmethod
     def _current_time_ns() -> int:
@@ -828,97 +1277,116 @@ class RivenVFS(pyfuse3.Operations):
         import time
         return int(time.time() * 1e9)
 
-    def _invalidate_directory_cache(self, file_path: str, parent_inodes: list[int]) -> None:
-        """Invalidate FUSE cache when adding files."""
-        try:
-            # Invalidate the immediate parent directory where the file was added
-            immediate_parent = self._normalize_path(self._get_parent_path(file_path))
-            if immediate_parent in self._path_to_inode:
-                parent_ino = self._path_to_inode[immediate_parent]
-                pyfuse3.invalidate_entry_async(parent_ino, os.path.basename(file_path).encode('utf-8'),
-                                               ignore_enoent=True)
-                log.trace(f"Invalidated directory entry for {file_path} in parent {immediate_parent}")
+    def _invalidate_entry(self, parent_path: str, entry_name: str, deleted_inode: Optional[int] = None,
+                         operation: str = "modify") -> None:
+        """
+        Helper to invalidate a directory entry in the kernel cache.
 
-            # Also invalidate any newly created parent directories
-            for ino in parent_inodes:
-                try:
-                    pyfuse3.invalidate_inode(ino, attr_only=True)
-                    log.trace(f"Invalidated inode {ino} for newly created parent directory")
-                except OSError as e:
-                    # Benign if kernel has not cached the inode yet
-                    if getattr(e, 'errno', None) == errno.ENOENT:
-                        log.trace(f"Skip invalidating uncached inode {ino} after adding {file_path}: {e}")
-                    else:
-                        raise
+        Args:
+            parent_path: Path to the parent directory
+            entry_name: Name of the entry to invalidate
+            deleted_inode: If provided, marks the entry as deleted with this inode
+            operation: Description of operation for logging (add/remove/rename)
+        """
+        try:
+            parent_node = self._get_node_by_path(parent_path)
+            if parent_node and parent_node.inode:
+                pyfuse3.invalidate_entry_async(
+                    parent_node.inode,
+                    entry_name.encode('utf-8'),
+                    deleted=deleted_inode or 0 if deleted_inode else 0,
+                    ignore_enoent=True
+                )
         except OSError as e:
-            # Downgrade ENOENT during add: often means kernel never cached the parent dir yet
-            if getattr(e, 'errno', None) == errno.ENOENT:
-                log.trace(f"Benign ENOENT while invalidating after adding {file_path}: {e}")
-            else:
-                log.warning(f"Failed to invalidate FUSE cache when adding {file_path}: {e}")
+            if getattr(e, 'errno', None) != errno.ENOENT:
+                log.warning(f"Failed to invalidate entry '{entry_name}' in {parent_path}: {e}")
+
+    def _invalidate_inode_list(self, inodes: list[int], attr_only: bool = True, operation: str = "modify") -> None:
+        """
+        Helper to invalidate a list of inodes.
+
+        Args:
+            inodes: List of inode numbers to invalidate
+            attr_only: If True, only invalidate attributes; if False, invalidate content too
+            operation: Description of operation for logging
+        """
+        for ino in inodes:
+            try:
+                pyfuse3.invalidate_inode(ino, attr_only=attr_only)
+            except OSError as e:
+                if getattr(e, 'errno', None) == errno.ENOENT:
+                    # Expected - inode not cached by kernel yet
+                    pass
+                else:
+                    log.warning(f"Failed to invalidate inode {ino}: {e}")
+
+    def _invalidate_directory_cache(self, file_path: str, parent_inodes: list[int]) -> None:
+        """
+        Invalidate FUSE cache when adding files.
+
+        Args:
+            file_path: NORMALIZED file path (caller must normalize)
+            parent_inodes: List of parent inodes to invalidate
+        """
+        # Invalidate the immediate parent directory entry
+        immediate_parent = self._get_parent_path(file_path)
+        self._invalidate_entry(immediate_parent, os.path.basename(file_path), operation="add")
+
+        # Invalidate any newly created parent directories
+        self._invalidate_inode_list(parent_inodes, attr_only=True, operation="add parent")
 
     def _invalidate_removed_entry_cache(self, file_path: str, inode: Optional[int]) -> None:
-        """Invalidate FUSE cache when removing files."""
-        try:
-            parent_path = self._normalize_path(self._get_parent_path(file_path))
-            if parent_path in self._path_to_inode:
-                parent_ino = self._path_to_inode[parent_path]
-                pyfuse3.invalidate_entry_async(parent_ino, os.path.basename(file_path).encode('utf-8'),
-                                               deleted=inode or 0, ignore_enoent=True)
-                log.trace(f"Invalidated directory entry for removed {file_path}")
-        except OSError as e:
-            if getattr(e, 'errno', None) == errno.ENOENT:
-                log.trace(f"Benign ENOENT while invalidating after removing {file_path}: {e}")
-            else:
-                log.warning(f"Failed to invalidate FUSE cache when removing {file_path}: {e}")
+        """
+        Invalidate FUSE cache when removing files.
+
+        Args:
+            file_path: NORMALIZED file path (caller must normalize)
+            inode: Inode of removed file
+        """
+        parent_path = self._get_parent_path(file_path)
+        self._invalidate_entry(parent_path, os.path.basename(file_path), deleted_inode=inode, operation="remove")
 
     def _invalidate_potentially_removed_dirs(self, file_path: str) -> None:
-        """Invalidate parent directory entries that may have been removed due to pruning."""
+        """
+        Invalidate parent directory entries that may have been removed due to pruning.
+
+        Args:
+            file_path: NORMALIZED file path (caller must normalize)
+        """
         try:
-            parent = self._normalize_path(self._get_parent_path(file_path))
-            grandparent = self._normalize_path(self._get_parent_path(parent))
+            parent = self._get_parent_path(file_path)
+            grandparent = self._get_parent_path(parent)
 
             # Invalidate the entry for 'parent' under its parent directory (grandparent)
-            if grandparent in self._path_to_inode:
-                name = os.path.basename(parent.rstrip('/'))
-                if name:
-                    pyfuse3.invalidate_entry_async(self._path_to_inode[grandparent], name.encode('utf-8'), ignore_enoent=True)
-                    log.trace(f"Invalidated potential removed dir entry '{name}' under {grandparent}")
+            name = os.path.basename(parent.rstrip('/'))
+            if name:
+                self._invalidate_entry(grandparent, name, operation="prune")
 
             # One more level up (e.g., title dir)
-            ggparent = self._normalize_path(self._get_parent_path(grandparent))
+            ggparent = self._get_parent_path(grandparent)
             gname = os.path.basename(grandparent.rstrip('/'))
-            if ggparent in self._path_to_inode and gname:
-                pyfuse3.invalidate_entry_async(self._path_to_inode[ggparent], gname.encode('utf-8'), ignore_enoent=True)
-                log.trace(f"Invalidated potential removed dir entry '{gname}' under {ggparent}")
+            if gname:
+                self._invalidate_entry(ggparent, gname, operation="prune")
         except Exception as e:
-            if getattr(e, 'errno', None) == errno.ENOENT:
-                log.trace(f"Benign ENOENT while invalidating parent dirs for {file_path}: {e}")
-            else:
+            if getattr(e, 'errno', None) != errno.ENOENT:
                 log.warning(f"Failed to invalidate parent dir entries for {file_path}: {e}")
-        except OSError as e:
-            log.warning(f"Failed to invalidate FUSE cache when removing {file_path}: {e}")
 
     def _invalidate_rename_cache(self, old_path: str, new_path: str, inode: Optional[int]) -> None:
-        """Invalidate FUSE cache when renaming files."""
-        try:
-            # Invalidate old parent directory
-            old_parent = self._normalize_path(self._get_parent_path(old_path))
-            if old_parent in self._path_to_inode:
-                old_parent_ino = self._path_to_inode[old_parent]
-                pyfuse3.invalidate_entry_async(old_parent_ino, os.path.basename(old_path).encode('utf-8'),
-                                               deleted=inode or 0, ignore_enoent=True)
-                log.trace(f"Invalidated old directory entry for renamed {old_path}")
+        """
+        Invalidate FUSE cache when renaming files.
 
-            # Invalidate new parent directory
-            new_parent = self._normalize_path(self._get_parent_path(new_path))
-            if new_parent in self._path_to_inode:
-                new_parent_ino = self._path_to_inode[new_parent]
-                pyfuse3.invalidate_entry_async(new_parent_ino, os.path.basename(new_path).encode('utf-8'),
-                                               ignore_enoent=True)
-                log.debug(f"Invalidated new directory entry for renamed {new_path}")
-        except OSError as e:
-            log.warning(f"Failed to invalidate FUSE cache when renaming {old_path} to {new_path}: {e}")
+        Args:
+            old_path: NORMALIZED old file path (caller must normalize)
+            new_path: NORMALIZED new file path (caller must normalize)
+            inode: Inode of renamed file
+        """
+        # Invalidate old parent directory (mark as deleted)
+        old_parent = self._get_parent_path(old_path)
+        self._invalidate_entry(old_parent, os.path.basename(old_path), deleted_inode=inode, operation="rename (old)")
+
+        # Invalidate new parent directory (mark as added)
+        new_parent = self._get_parent_path(new_path)
+        self._invalidate_entry(new_parent, os.path.basename(new_path), operation="rename (new)")
 
     # FUSE Operations
     async def getattr(self, inode: int, ctx=None) -> pyfuse3.EntryAttributes:
@@ -950,52 +1418,59 @@ class RivenVFS(pyfuse3.Operations):
                 attrs.st_ctime_ns = now_ns
                 return attrs
 
-            # For other paths, check database
-            entry_info = self._get_entry_cached(path)
-            if entry_info is None:
+            # For other paths, get node from tree
+            node = self._get_node_by_path(path)
+            if node is None:
                 raise pyfuse3.FUSEError(errno.ENOENT)
 
-            # Use created_at timestamp from database for consistent file attributes
-            # This prevents media players from thinking files have changed
-            created_ts = entry_info.get("created")
-            modified_ts = entry_info.get("modified")
+            # Check if it's a directory
+            if node.is_directory:
+                # This is a virtual directory (e.g., /kids, /anime, /movies)
+                attrs.st_mode = stat.S_IFDIR | 0o755
+                attrs.st_nlink = 2
+                attrs.st_size = 0
+                now_ns = self._current_time_ns()
+                attrs.st_atime_ns = now_ns
+                attrs.st_mtime_ns = now_ns
+                attrs.st_ctime_ns = now_ns
+                return attrs
 
-            if created_ts:
+            # It's a file - use cached metadata from node (NO DATABASE QUERY!)
+            # Metadata was populated during sync_library_profiles()
+
+            # Parse timestamps from cached metadata
+            if node.created_at:
                 from datetime import datetime
                 try:
-                    created_dt = datetime.fromisoformat(created_ts)
+                    created_dt = datetime.fromisoformat(node.created_at)
                     created_ns = int(created_dt.timestamp() * 1_000_000_000)
                 except Exception:
                     created_ns = self._current_time_ns()
             else:
                 created_ns = self._current_time_ns()
 
-            if modified_ts:
+            if node.updated_at:
                 from datetime import datetime
                 try:
-                    modified_dt = datetime.fromisoformat(modified_ts)
-                    modified_ns = int(modified_dt.timestamp() * 1_000_000_000)
+                    updated_dt = datetime.fromisoformat(node.updated_at)
+                    updated_ns = int(updated_dt.timestamp() * 1_000_000_000)
                 except Exception:
-                    modified_ns = created_ns
+                    updated_ns = created_ns
             else:
-                modified_ns = created_ns
+                updated_ns = created_ns
 
             # Set timestamps: ctime = creation, mtime = modification, atime = access (use mtime)
             attrs.st_ctime_ns = created_ns
-            attrs.st_mtime_ns = modified_ns
-            attrs.st_atime_ns = modified_ns  # Use mtime for atime to avoid constant updates
+            attrs.st_mtime_ns = updated_ns
+            attrs.st_atime_ns = updated_ns  # Use mtime for atime to avoid constant updates
 
-            if entry_info["is_directory"]:
-                attrs.st_mode = stat.S_IFDIR | 0o755
-                attrs.st_nlink = 2
-                attrs.st_size = 0
-            else:
-                attrs.st_mode = stat.S_IFREG | 0o644
-                attrs.st_nlink = 1
-                size = int(entry_info.get("size") or 0)
-                if size == 0:
-                    size = 1337 * 1024 * 1024  # Default size when unknown
-                attrs.st_size = size
+            # We already know it's a file from node.is_directory check above
+            attrs.st_mode = stat.S_IFREG | 0o644
+            attrs.st_nlink = 1
+            size = int(node.file_size or 0)
+            if size == 0:
+                size = 1337 * 1024 * 1024  # Default size when unknown
+            attrs.st_size = size
 
             return attrs
         except pyfuse3.FUSEError:
@@ -1005,22 +1480,31 @@ class RivenVFS(pyfuse3.Operations):
             raise pyfuse3.FUSEError(errno.EIO)
 
     async def lookup(self, parent_inode: int, name: bytes, ctx=None) -> pyfuse3.EntryAttributes:
-        """Look up a directory entry."""
+        """Look up a directory entry using VFS tree."""
         try:
-            parent_path = self._get_path_from_inode(parent_inode)
-            name_str = name.decode('utf-8')
+            with self._tree_lock:
+                # Get parent node from tree
+                parent_node = self._inode_to_node.get(parent_inode)
+                if parent_node is None:
+                    raise pyfuse3.FUSEError(errno.ENOENT)
 
-            if name_str == '.':
-                return await self.getattr(parent_inode)
-            if name_str == '..':
-                parent_inode = self._path_to_inode.get(self._get_parent_path(parent_path), pyfuse3.ROOT_INODE)
-                return await self.getattr(parent_inode)
+                name_str = name.decode('utf-8')
 
-            child_path = self._join_paths(parent_path, name_str)
-            if not self._exists_cached(child_path):
-                raise pyfuse3.FUSEError(errno.ENOENT)
+                if name_str == '.':
+                    child_inode = parent_inode
+                elif name_str == '..':
+                    # Get parent's parent
+                    if parent_node.parent:
+                        child_inode = parent_node.parent.inode
+                    else:
+                        child_inode = pyfuse3.ROOT_INODE
+                else:
+                    # Look up child in parent's children
+                    child_node = parent_node.get_child(name_str)
+                    if child_node is None:
+                        raise pyfuse3.FUSEError(errno.ENOENT)
+                    child_inode = child_node.inode
 
-            child_inode = self._assign_inode(child_path)
             return await self.getattr(child_inode)
         except pyfuse3.FUSEError:
             raise
@@ -1031,15 +1515,16 @@ class RivenVFS(pyfuse3.Operations):
     async def opendir(self, inode: int, ctx):
         """Open a directory for reading."""
         try:
-            path = self._get_path_from_inode(inode)
+            with self._tree_lock:
+                # Get node from tree
+                node = self._inode_to_node.get(inode)
+                if node is None:
+                    raise pyfuse3.FUSEError(errno.ENOENT)
 
-            # Special case for root directory
-            if path == "/":
-                return inode  # Return the inode as file handle
+                # Check if it's a directory
+                if not node.is_directory:
+                    raise pyfuse3.FUSEError(errno.ENOTDIR)
 
-            entry_info = self._get_entry_cached(path)
-            if entry_info is None or not entry_info["is_directory"]:
-                raise pyfuse3.FUSEError(errno.ENOTDIR)
             return inode  # Return the inode as file handle for directories
         except pyfuse3.FUSEError:
             raise
@@ -1054,15 +1539,21 @@ class RivenVFS(pyfuse3.Operations):
             entries = self._list_directory_cached(path)
 
             # Build directory listing
-            items = [
-                (b'.', inode),
-                (b'..', self._path_to_inode.get(self._get_parent_path(path), pyfuse3.ROOT_INODE))
-            ]
+            with self._tree_lock:
+                node = self._inode_to_node.get(inode)
+                parent_inode = node.parent.inode if node and node.parent else pyfuse3.ROOT_INODE
 
-            for entry in entries:
-                name_bytes = entry["name"].encode('utf-8')
-                child_inode = self._assign_inode(self._join_paths(path, entry["name"]))
-                items.append((name_bytes, child_inode))
+                items = [
+                    (b'.', inode),
+                    (b'..', parent_inode)
+                ]
+
+                for entry in entries:
+                    name_bytes = entry["name"].encode('utf-8')
+                    # Get child node from tree
+                    child_node = node.get_child(entry["name"]) if node else None
+                    if child_node and child_node.inode:
+                        items.append((name_bytes, child_node.inode))
 
             # Send directory entries starting from offset
             for idx in range(off, len(items)):
@@ -1079,25 +1570,31 @@ class RivenVFS(pyfuse3.Operations):
     async def open(self, inode: int, flags: int, ctx):
         """Open a file for reading."""
         try:
-            path = self._get_path_from_inode(inode)
-            file_info = self._get_entry_cached(path)
+            with self._tree_lock:
+                # Get node from tree and verify it's a file
+                node = self._inode_to_node.get(inode)
+                if node is None or node.is_directory:
+                    raise pyfuse3.FUSEError(errno.EISDIR if node and node.is_directory else errno.ENOENT)
+
+                path = node.get_full_path()
+                # Cache metadata from node
+                file_size = node.file_size
+                entry_type = node.entry_type
 
             log.trace(f"Opening file {path} (inode={inode}) with flags {flags})")
-
-            if file_info is None or file_info["is_directory"]:
-                raise pyfuse3.FUSEError(errno.ENOENT)
 
             # Only allow read access
             if flags & os.O_RDWR or flags & os.O_WRONLY:
                 raise pyfuse3.FUSEError(errno.EACCES)
 
-            # Create file handle with readahead buffer
+            # Create file handle with cached node metadata (no DB query!)
             fh = self._next_fh
             self._next_fh += 1
-            # Minimal handle info
+            # Store metadata in handle (don't store node reference to avoid holding lock)
             self._file_handles[fh] = {
                 "path": path,
-                "file_info": file_info,
+                "file_size": file_size,
+                "entry_type": entry_type,
                 "is_scanner": False,  # Will be detected based on read pattern (large jumps)
                 "buffers": [],
                 "sequential_reads": 0,
@@ -1131,25 +1628,24 @@ class RivenVFS(pyfuse3.Operations):
             if not path:
                 raise pyfuse3.FUSEError(errno.EBADF)
 
-            file_info = handle_info.get("file_info") or self._get_entry_cached(path)
-            if file_info is None or file_info.get("is_directory"):
-                raise pyfuse3.FUSEError(errno.ENOENT)
-            size_raw = file_info.get("size")
-            file_size = int(size_raw) if size_raw is not None else None
+            # Get cached metadata from file handle (populated in open())
+            file_size = handle_info.get("file_size")
+            entry_type = handle_info.get("entry_type")
 
             if size == 0:
                 return b""
 
             # Check if this is a subtitle entry - if so, read from database instead of HTTP
-            entry_type = file_info.get("entry_type")
             if entry_type == "subtitle":
                 # Subtitles are stored in the database, not fetched via HTTP
                 # Check if we've already cached the subtitle content in the handle
                 subtitle_content = handle_info.get("subtitle_content")
                 if subtitle_content is None:
+                    # Resolve path alias before querying database for subtitle content
+                    resolved_path = self._resolve_path(path)
                     # Fetch subtitle content from database (blocking call, but subtitles are small)
                     subtitle_content = await trio.to_thread.run_sync(
-                        lambda: self.db.get_subtitle_content(path)
+                        lambda: self.db.get_subtitle_content(resolved_path)
                     )
                     if subtitle_content is None:
                         log.error(f"Subtitle content not found for {path}")
@@ -1170,14 +1666,19 @@ class RivenVFS(pyfuse3.Operations):
 
             # For media entries, continue with normal HTTP streaming logic
 
+            # Resolve path alias to base path for consistent cache keys
+            # This ensures cache is shared between base path and all alias paths
+            resolved_path = self._resolve_path(path)
+
             import time
             now = time.time()
-            cached_url_info = self._url_cache.get(path)
+            cached_url_info = self._url_cache.get(resolved_path)
             if not cached_url_info or (now - float(cached_url_info.get("timestamp", 0))) > self.url_cache_ttl:
-                url = self.db.get_download_url(path, for_http=True, force_resolve=False)
+                # Query database for download URL using resolved path
+                url = self.db.get_download_url(resolved_path, for_http=True, force_resolve=False)
                 if not url:
                     raise pyfuse3.FUSEError(errno.ENOENT)
-                self._url_cache[path] = {"url": url, "timestamp": now}
+                self._url_cache[resolved_path] = {"url": url, "timestamp": now}
             else:
                 url = str(cached_url_info.get("url"))
 
@@ -1217,7 +1718,8 @@ class RivenVFS(pyfuse3.Operations):
                             except Exception as e:
                                 log.trace(f"Footer prefetch failed: {e}")
 
-                        trio.lowlevel.spawn_system_task(_prefetch_footer, path, url, footer_chunk_start, footer_chunk_end)
+                        # Use resolved_path for footer prefetch to share cache between base and alias paths
+                        trio.lowlevel.spawn_system_task(_prefetch_footer, resolved_path, url, footer_chunk_start, footer_chunk_end)
 
             # Update last read offset for next jump detection
             handle_info["last_read_offset"] = off
@@ -1243,18 +1745,19 @@ class RivenVFS(pyfuse3.Operations):
                     return b""
 
                 # Try cache first for exactly what kernel asked (async to avoid blocking event loop)
+                # Use resolved_path for cache to share cache between base and alias paths
                 cached_bytes = await trio.to_thread.run_sync(
-                    lambda: self.cache.get(path, off, off + size - 1)
+                    lambda: self.cache.get(resolved_path, off, off + size - 1)
                 )
                 if cached_bytes is not None:
                     returned_data = cached_bytes
                 else:
                     # Fetch the determined range (exact for non-promoted, larger for promoted)
-                    data = await self._fetch_data_block(path, url, fetch_start, fetch_end)
+                    data = await self._fetch_data_block(resolved_path, url, fetch_start, fetch_end)
                     if data:
                         # Cache immediately (async to avoid blocking event loop)
                         await trio.to_thread.run_sync(
-                            lambda: self.cache.put(path, fetch_start, data)
+                            lambda: self.cache.put(resolved_path, fetch_start, data)
                         )
 
                         # Always slice to return exactly what was requested
@@ -1308,8 +1811,9 @@ class RivenVFS(pyfuse3.Operations):
                 next_aligned_end = next_aligned_start + self.chunk_size - 1
 
                 # Try cache first for the exact request (cache handles chunk lookup and slicing)
+                # Use resolved_path for cache to share cache between base and alias paths
                 cached_bytes = await trio.to_thread.run_sync(
-                    lambda: self.cache.get(path, request_start, request_end)
+                    lambda: self.cache.get(resolved_path, request_start, request_end)
                 )
 
                 if cached_bytes is not None:
@@ -1328,15 +1832,15 @@ class RivenVFS(pyfuse3.Operations):
 
                         # Check if this chunk is cached (full chunk)
                         chunk_data = await trio.to_thread.run_sync(
-                            lambda cs=current_chunk_start, ce=chunk_end: self.cache.get(path, cs, ce)
+                            lambda cs=current_chunk_start, ce=chunk_end: self.cache.get(resolved_path, cs, ce)
                         )
                         if chunk_data is None:
                             # Fetch this chunk
-                            chunk_data = await self._fetch_data_block(path, url, current_chunk_start, chunk_end)
+                            chunk_data = await self._fetch_data_block(resolved_path, url, current_chunk_start, chunk_end)
                             if chunk_data:
                                 # Cache immediately (async to avoid blocking event loop)
                                 await trio.to_thread.run_sync(
-                                    lambda: self.cache.put(path, current_chunk_start, chunk_data)
+                                    lambda: self.cache.put(resolved_path, current_chunk_start, chunk_data)
                                 )
 
                         if chunk_data:
@@ -1375,7 +1879,8 @@ class RivenVFS(pyfuse3.Operations):
                 if handle_info["sequential_reads"] >= 3:
                     if file_size is None or next_aligned_start < file_size:
                         pf_end = next_aligned_end if file_size is None else min(next_aligned_end, file_size - 1)
-                        trio.lowlevel.spawn_system_task(self._prefetch_next_chunk, fh, path, url, next_aligned_start, pf_end)
+                        # Use resolved_path for prefetch to share cache between base and alias paths
+                        trio.lowlevel.spawn_system_task(self._prefetch_next_chunk, fh, resolved_path, url, next_aligned_start, pf_end)
 
                 opener = handle_info.get("opener_name")
                 if opener and returned_data:
@@ -1562,10 +2067,11 @@ class RivenVFS(pyfuse3.Operations):
         Be permissive for write checks to avoid client false negatives; actual writes still fail with EROFS.
         """
         try:
-            # Check existence only; permission enforcement happens at operation time
-            path = self._get_path_from_inode(inode)
-            if not self.db.exists(path):
-                raise pyfuse3.FUSEError(errno.ENOENT)
+            with self._tree_lock:
+                # Check existence in tree (no database query needed!)
+                node = self._inode_to_node.get(inode)
+                if node is None:
+                    raise pyfuse3.FUSEError(errno.ENOENT)
             return None
         except pyfuse3.FUSEError:
             raise

--- a/src/program/services/indexers/tvdb_indexer.py
+++ b/src/program/services/indexers/tvdb_indexer.py
@@ -134,6 +134,19 @@ class TVDBIndexer(BaseIndexer):
             title = regex.sub(r"\s*\(.*\)\s*$", "", title)
             release_data = self.api.get_series_release_data(show_data) or {}
 
+            # Extract rating (TVDB doesn't provide ratings directly, set to None)
+            rating = None
+
+            # Extract US content rating
+            content_rating = None
+            if hasattr(show_data, "contentRatings") and show_data.contentRatings:
+                # Look for US content rating
+                for rating_obj in show_data.contentRatings:
+                    if hasattr(rating_obj, "country") and rating_obj.country == "usa":
+                        if hasattr(rating_obj, "name") and rating_obj.name:
+                            content_rating = rating_obj.name
+                            break
+
             show_item = {
                 "title": title,
                 "year": int(show_data.firstAired.split("-")[0]) if show_data.firstAired else None,
@@ -151,6 +164,8 @@ class TVDBIndexer(BaseIndexer):
                 "is_anime": is_anime,
                 "aliases": aliases,
                 "release_data": release_data,
+                "rating": rating,
+                "content_rating": content_rating,
             }
 
             return Show(show_item)

--- a/src/program/services/library_profile_matcher.py
+++ b/src/program/services/library_profile_matcher.py
@@ -1,0 +1,241 @@
+"""Library Profile Matcher Service
+
+Evaluates MediaItem metadata against library profile filter rules to determine
+which library profiles a media item should be placed in.
+"""
+
+from typing import List, Optional
+from loguru import logger
+
+from program.media.item import MediaItem
+from program.settings.models import LibraryProfile, LibraryProfileFilterRules
+from program.settings.manager import settings_manager
+
+
+class LibraryProfileMatcher:
+    """
+    Service for matching MediaItems against library profile filter rules.
+    
+    Evaluates metadata-only filters (genres, rating, year, etc.) to determine
+    which library profiles a media item belongs to.
+    
+    Note: Cannot filter on scraping results (resolution, codec, HDR) as those
+    are not available from indexers - only from scrapers.
+    """
+    
+    def __init__(self):
+        self.key = "library_profile_matcher"
+    
+    def get_matching_profiles(self, item: MediaItem) -> List[str]:
+        """
+        Get list of library profile keys that match the given MediaItem.
+
+        Evaluates all enabled library profiles and returns those whose filter
+        rules match the item's metadata. Profiles are returned in the order
+        they appear in settings (dict insertion order).
+
+        Args:
+            item: MediaItem to evaluate
+
+        Returns:
+            List of profile keys (e.g., ['kids', 'anime']) in settings order.
+            Empty list if no profiles match.
+
+        Example:
+            >>> matcher = LibraryProfileMatcher()
+            >>> profiles = matcher.get_matching_profiles(movie_item)
+            >>> # ['kids', 'family']  # Movie matches both profiles
+        """
+        profiles = settings_manager.settings.filesystem.library_profiles or {}
+
+        matching_profiles = []
+
+        for profile_key, profile in profiles.items():
+            # Skip disabled profiles
+            if not profile.enabled:
+                continue
+
+            # Evaluate filter rules
+            if self._matches_filter_rules(item, profile.filter_rules):
+                matching_profiles.append(profile_key)
+
+        return matching_profiles
+    
+    def _matches_filter_rules(self, item: MediaItem, rules: LibraryProfileFilterRules) -> bool:
+        """
+        Check if a MediaItem matches the given filter rules.
+        
+        All specified rules must match (AND logic). If a rule is None/empty,
+        it's considered a match (no filtering on that criterion).
+        
+        Args:
+            item: MediaItem to evaluate
+            rules: Filter rules to evaluate against
+        
+        Returns:
+            True if all specified rules match, False otherwise
+        """
+        # Content type filter (movie, show, season, episode)
+        # Hierarchical matching: "show" matches show/season/episode, "movie" matches movie only
+        if rules.content_types:
+            if not self._matches_content_type(item.type, rules.content_types):
+                return False
+
+        # Genre filters (must have at least one matching genre)
+        if rules.genres:
+            item_genres = self._get_normalized_genres(item)
+            if not item_genres:
+                return False
+
+            # Check if any of the required genres are present
+            if not any(genre in item_genres for genre in rules.genres):
+                return False
+
+        # Excluded genre filter (must not have any excluded genres)
+        if rules.exclude_genres:
+            item_genres = self._get_normalized_genres(item)
+            if item_genres:
+                # Check if any excluded genres are present
+                if any(genre in item_genres for genre in rules.exclude_genres):
+                    return False
+
+        # Year filters
+        if rules.min_year is not None or rules.max_year is not None:
+            item_year = self._get_year(item)
+            if item_year is None:
+                return False
+
+            if rules.min_year is not None and item_year < rules.min_year:
+                return False
+
+            if rules.max_year is not None and item_year > rules.max_year:
+                return False
+
+        # Anime filter
+        if rules.is_anime is not None:
+            if item.is_anime != rules.is_anime:
+                return False
+
+        # Network filter (for TV shows)
+        if rules.networks:
+            item_networks = self._get_normalized_networks(item)
+            if not item_networks:
+                return False
+
+            # Check if any of the required networks are present
+            if not any(network in item_networks for network in rules.networks):
+                return False
+
+        # Country filter
+        if rules.countries:
+            item_countries = self._get_normalized_countries(item)
+            if not item_countries:
+                return False
+
+            # Check if any of the required countries are present
+            if not any(country in item_countries for country in rules.countries):
+                return False
+
+        # Language filter
+        if rules.languages:
+            item_languages = self._get_normalized_languages(item)
+            if not item_languages:
+                return False
+            
+            # Check if any of the required languages are present
+            if not any(lang in item_languages for lang in rules.languages):
+                return False
+
+        # Rating filters (0-10 scale)
+        if rules.min_rating is not None or rules.max_rating is not None:
+            if item.rating is None:
+                return False
+
+            if rules.min_rating is not None and item.rating < rules.min_rating:
+                return False
+
+            if rules.max_rating is not None and item.rating > rules.max_rating:
+                return False
+
+        # Content rating filter (US ratings: G, PG, PG-13, R, etc.)
+        if rules.content_ratings:
+            if not item.content_rating:
+                return False
+
+            if item.content_rating not in rules.content_ratings:
+                return False
+        
+        # All rules matched
+        return True
+
+    def _matches_content_type(self, item_type: str, allowed_types: List[str]) -> bool:
+        """
+        Check if item type matches allowed content types with hierarchical matching.
+
+        Hierarchical rules:
+        - "movie" matches: movie only
+        - "show" matches: show, season, episode (entire show hierarchy)
+
+        Args:
+            item_type: The type of the MediaItem (movie, show, season, episode)
+            allowed_types: List of allowed content types from filter rules
+
+        Returns:
+            True if item type matches any allowed type (with hierarchy), False otherwise
+        """
+        # Direct match
+        if item_type in allowed_types:
+            return True
+
+        # Hierarchical matching: if "show" is allowed, also allow season and episode
+        if "show" in allowed_types and item_type in ["season", "episode"]:
+            return True
+
+        return False
+
+    def _get_normalized_genres(self, item: MediaItem) -> List[str]:
+        """Get normalized genre list (lowercase) from MediaItem."""
+        if not item.genres:
+            return []
+        return [g.lower() for g in item.genres if g]
+    
+    def _get_normalized_networks(self, item: MediaItem) -> List[str]:
+        """Get normalized network list (lowercase) from MediaItem."""
+        if not item.network:
+            return []
+        return [n.lower() for n in item.network if n]
+    
+    def _get_normalized_countries(self, item: MediaItem) -> List[str]:
+        """Get normalized country list (lowercase) from MediaItem."""
+        if not item.country:
+            return []
+        return [c.lower() for c in item.country if c]
+    
+    def _get_normalized_languages(self, item: MediaItem) -> List[str]:
+        """Get normalized language list (lowercase) from MediaItem."""
+        if not item.language:
+            return []
+        return [lang.lower() for lang in item.language if lang]
+    
+    def _get_year(self, item: MediaItem) -> Optional[int]:
+        """
+        Extract year from MediaItem.
+        
+        For shows/seasons/episodes, uses the show's aired_at year.
+        For movies, uses the year field directly.
+        """
+        if item.type in ["show", "season", "episode"]:
+            # For TV content, get the show's aired_at year
+            show = item.get_top_title()
+            if show and hasattr(show, 'aired_at') and show.aired_at:
+                try:
+                    return int(show.aired_at.split('-')[0])
+                except (ValueError, IndexError, AttributeError):
+                    return None
+        
+        # For movies or if show year not available, use year field
+        if hasattr(item, 'year') and item.year:
+            return item.year
+        
+        return None
+

--- a/src/program/services/updaters/__init__.py
+++ b/src/program/services/updaters/__init__.py
@@ -38,11 +38,13 @@ class Updater:
         """
         Update media servers for the given item.
 
-        Extracts the filesystem path from the item and triggers a refresh
-        in all initialized media servers.
+        Extracts all filesystem paths (base + library profiles) from the item
+        and triggers a refresh in all initialized media servers.
 
         For movies: refreshes parent directory (e.g., /movies/Movie Name (2020)/)
         For shows: refreshes parent's parent directory (e.g., /shows/Show Name/)
+
+        Library profiles: Also refreshes profile paths (e.g., /kids/movies/Movie Name/)
 
         Args:
             item: MediaItem to update
@@ -52,26 +54,28 @@ class Updater:
         """
         logger.debug(f"Starting update process for {item.log_string}")
         items = self.get_items_to_update(item)
-        last_path = None
+        refreshed_paths = set()  # Track refreshed paths to avoid duplicates
 
         for _item in items:
-            logger.debug(f"Updating {_item.log_string} at {_item.filesystem_entry.path}")
-            # Get the filesystem path from the item
-            fe_path = _item.filesystem_entry.path
+            # Get all VFS paths for this item (base path + library profile paths)
+            all_vfs_paths = _item.filesystem_entry.get_library_paths()
 
-            # Build absolute path to the file
-            abs_path = os.path.join(self.library_path, fe_path.lstrip("/"))
-            refresh_path = os.path.dirname(abs_path)
+            logger.debug(f"Updating {_item.log_string} at {len(all_vfs_paths)} path(s)")
 
-            # Refresh the path in all services
-            if refresh_path != last_path:
-                self.refresh_path(refresh_path)
-            last_path = refresh_path
+            for vfs_path in all_vfs_paths:
+                # Build absolute path to the file
+                abs_path = os.path.join(self.library_path, vfs_path.lstrip("/"))
+                refresh_path = os.path.dirname(abs_path)
+
+                # Refresh the path in all services (skip if already refreshed)
+                if refresh_path not in refreshed_paths:
+                    if self.refresh_path(refresh_path):
+                        refreshed_paths.add(refresh_path)
 
             _item.updated = True
             logger.debug(f"Updated {_item.log_string}")
 
-        logger.info(f"Updated {item.log_string}")
+        logger.info(f"Updated {item.log_string} ({len(refreshed_paths)} unique paths refreshed)")
         yield item
 
     def refresh_path(self, path: str) -> bool:
@@ -96,9 +100,6 @@ class Updater:
                         success = True
                 except Exception as e:
                     logger.error(f"Failed to refresh path {path}: {e}")
-
-        if not success:
-            logger.debug(f"No updater service successfully refreshed path {path}")
 
         return success
     

--- a/src/program/settings/manager.py
+++ b/src/program/settings/manager.py
@@ -84,7 +84,7 @@ class SettingsManager:
     def save(self):
         """Save settings to file, using Pydantic model for JSON serialization."""
         with open(self.settings_file, "w", encoding="utf-8") as file:
-            file.write(self.settings.model_dump_json(indent=4))
+            file.write(self.settings.model_dump_json(indent=4, exclude_none=True))
 
 
 def format_validation_error(e: ValidationError) -> str:

--- a/src/program/settings/migratable.py
+++ b/src/program/settings/migratable.py
@@ -1,11 +1,27 @@
 ﻿from pydantic import BaseModel
+from pydantic_core import PydanticUndefined
 
 
 class MigratableBaseModel(BaseModel):
     def __init__(self, **data):
         for field_name, field in self.model_fields.items():
+            # Handle missing fields
             if field_name not in data:
-                default_value = field.default if field.default is not None else None
-                data[field_name] = default_value
+                # Check for default_factory first
+                if field.default_factory is not None and field.default_factory != PydanticUndefined:
+                    data[field_name] = field.default_factory()
+                # Then check for default value
+                elif field.default is not None and field.default != PydanticUndefined:
+                    data[field_name] = field.default
+                else:
+                    data[field_name] = None
+            # Handle empty dicts that should have default_factory content
+            elif isinstance(data[field_name], dict) and len(data[field_name]) == 0:
+                # If field has a default_factory and the dict is empty, populate with defaults
+                if field.default_factory is not None and field.default_factory != PydanticUndefined:
+                    default_value = field.default_factory()
+                    # Only replace empty dict if default_factory returns non-empty dict
+                    if isinstance(default_value, dict) and len(default_value) > 0:
+                        data[field_name] = default_value
         super().__init__(**data)
 


### PR DESCRIPTION
# Pull Request Check List

Resolves: #877 

BEGIN_COMMIT_OVERRIDE
Library profiles: metadata-based filters that surface items under profile-prefixed virtual library paths.
END_COMMIT_OVERRIDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library profiles: metadata-based filters that surface items under profile-prefixed virtual library paths.
  * Items now include rating and content rating where available; profile matching exposes per-item profile keys.

* **Refactor**
  * VFS and mount/refresh flows synchronized with library profiles, support multiple paths per item and shared caching; canonical base paths simplified to /movies and /shows.
  * Filesystem service reinitialization replaced by in-place synchronization.

* **Documentation**
  * Added "Library Profiles" guide and content ratings reference.

* **Chores**
  * Database migration to add rating, content_rating, and library_profiles; settings serialization omits None fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->