### PR TITLE
perf(scraping): no more pesky imdb-only service roundup on every scrape

### DIFF
--- a/src/program/services/scrapers/comet.py
+++ b/src/program/services/scrapers/comet.py
@@ -94,11 +94,13 @@ class Comet(ScraperService):
                 logger.error(f"Comet exception thrown: {str(e)}")
         return {}
 
-    def scrape(self, item: MediaItem) -> tuple[Dict[str, str], int]:
+    def scrape(self, item: MediaItem) -> Dict[str, str]:
         """Wrapper for `Comet` scrape method"""
         identifier, scrape_type, imdb_id = self.get_stremio_identifier(item)
+        if not imdb_id:
+            return {}
+        
         url = f"/{self.encoded_string}/stream/{scrape_type}/{imdb_id}{identifier or ''}.json"
-
         response = self.session.get(url, timeout=self.timeout)
         if not response.ok or not getattr(response.data, "streams", None):
             logger.log("NOT_FOUND", f"No streams found for {item.log_string}")

--- a/src/program/services/scrapers/mediafusion.py
+++ b/src/program/services/scrapers/mediafusion.py
@@ -103,9 +103,11 @@ class Mediafusion(ScraperService):
                 logger.exception(f"Mediafusion exception thrown: {e}")
         return {}
 
-    def scrape(self, item: MediaItem) -> tuple[Dict[str, str], int]:
+    def scrape(self, item: MediaItem) -> Dict[str, str]:
         """Wrapper for `Mediafusion` scrape method"""
         identifier, scrape_type, imdb_id = self.get_stremio_identifier(item)
+        if not imdb_id:
+            return {}
 
         url = f"/{self.encrypted_string}/stream/{scrape_type}/{imdb_id}"
         if identifier:

--- a/src/program/services/scrapers/orionoid.py
+++ b/src/program/services/scrapers/orionoid.py
@@ -101,9 +101,6 @@ class Orionoid(ScraperService):
 
     def run(self, item: MediaItem) -> Dict[str, str]:
         """Scrape the orionoid site for the given media items and update the object with scraped streams."""
-        if not item:
-            return {}
-
         if not self.is_unlimited:
             limit_hit = self.check_limit()
             if limit_hit:


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:

BEGIN_COMMIT_OVERRIDE
perf(scraping): Improve scraping performance by removing redundant operations
END_COMMIT_OVERRIDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when items lack IMDb IDs, avoiding errors and inconsistent results.
  * More consistent scraping outcomes across services.

* **Performance**
  * Streamlined concurrent execution to always use initialized services, improving speed and predictability.

* **Refactor**
  * Standardized scraper outputs to a single, consistent result format, reducing edge cases and simplifying handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->