### PR TITLE
feat(models): add total_downloaded_bytes and cooldown_until fields to UserInfo

### DIFF
--- a/src/program/services/downloaders/models.py
+++ b/src/program/services/downloaders/models.py
@@ -212,3 +212,5 @@ class UserInfo(BaseModel):
 
     # Service-specific fields (optional)
     points: Optional[int] = None  # Real-Debrid
+    total_downloaded_bytes: Optional[int] = None
+    cooldown_until: Optional[datetime] = None


### PR DESCRIPTION
otherwise you get ` | 25-11-01 13:57:13 | :x: ERROR     | default.download_user_info - Error getting user info from debridlink: 'UserInfo' object has no attribute 'total_downloaded_bytes'` with `chore/switch-to-streaming-over-chunking` branch