### PR TITLE
Fix/downloader proxies

### DIFF
--- a/src/program/services/downloaders/alldebrid.py
+++ b/src/program/services/downloaders/alldebrid.py
@@ -42,15 +42,17 @@ class AllDebridAPI:
         # AllDebrid rate limits: 12 req/sec and 600 req/min
         # Using conservative 10 req/sec (600 capacity)
         rate_limits = {"api.alldebrid.com": {"rate": 10, "capacity": 600}}
+        proxies = None
+        if proxy_url:
+            proxies = {"http": proxy_url, "https": proxy_url}
         self.session = SmartSession(
             base_url=self.BASE_URL,
             rate_limits=rate_limits,
+            proxies=proxies,
             retries=2,
             backoff_factor=0.5,
         )
         self.session.headers.update({"Authorization": f"Bearer {api_key}"})
-        if proxy_url:
-            self.session.proxies.update({"http": proxy_url, "https": proxy_url})
 
 
 class AllDebridDownloader(DownloaderBase):
@@ -79,7 +81,7 @@ class AllDebridDownloader(DownloaderBase):
         if not self._validate_settings():
             return False
 
-        proxy_url = getattr(self, "PROXY_URL", None) or None
+        proxy_url = self.PROXY_URL or None
         self.api = AllDebridAPI(api_key=self.settings.api_key, proxy_url=proxy_url)
         return self._validate_premium()
 

--- a/src/program/services/downloaders/debridlink.py
+++ b/src/program/services/downloaders/debridlink.py
@@ -42,15 +42,17 @@ class DebridLinkAPI:
         # Conservative rate limiting - Debrid-Link doesn't specify exact limits
         # Using 60 req/min as a safe default
         rate_limits = {"debrid-link.com": {"rate": 1, "capacity": 60}}
+        proxies = None
+        if proxy_url:
+            proxies = {"http": proxy_url, "https": proxy_url}
         self.session = SmartSession(
             base_url=self.BASE_URL,
             rate_limits=rate_limits,
+            proxies=proxies,
             retries=2,
             backoff_factor=0.5,
         )
         self.session.headers.update({"Authorization": f"Bearer {api_key}"})
-        if proxy_url:
-            self.session.proxies.update({"http": proxy_url, "https": proxy_url})
 
 
 class DebridLinkDownloader(DownloaderBase):
@@ -79,7 +81,7 @@ class DebridLinkDownloader(DownloaderBase):
         if not self._validate_settings():
             return False
 
-        proxy_url = getattr(self, "PROXY_URL", None) or None
+        proxy_url = self.PROXY_URL or None
         self.api = DebridLinkAPI(api_key=self.settings.api_key, proxy_url=proxy_url)
         return self._validate_premium()
 

--- a/src/program/services/downloaders/realdebrid.py
+++ b/src/program/services/downloaders/realdebrid.py
@@ -43,15 +43,17 @@ class RealDebridAPI:
 
         # 250 req/min ~= 4.17 rps with capacity 250
         rate_limits = {"api.real-debrid.com": {"rate": 250 / 60, "capacity": 250}}
+        proxies = None
+        if proxy_url:
+            proxies = {"http": proxy_url, "https": proxy_url}
         self.session = SmartSession(
             base_url=self.BASE_URL,
             rate_limits=rate_limits,
+            proxies=proxies,
             retries=2,
             backoff_factor=0.5,
         )
         self.session.headers.update({"Authorization": f"Bearer {api_key}"})
-        if proxy_url:
-            self.session.proxies.update({"http": proxy_url, "https": proxy_url})
 
 
 class RealDebridDownloader(DownloaderBase):
@@ -80,7 +82,7 @@ class RealDebridDownloader(DownloaderBase):
         if not self._validate_settings():
             return False
 
-        proxy_url = getattr(self, "PROXY_URL", None) or None
+        proxy_url = self.PROXY_URL or None
         self.api = RealDebridAPI(api_key=self.settings.api_key, proxy_url=proxy_url)
         return self._validate_premium()
 

--- a/src/program/services/indexers/tvdb_indexer.py
+++ b/src/program/services/indexers/tvdb_indexer.py
@@ -174,8 +174,8 @@ class TVDBIndexer(BaseIndexer):
                                 [alias for alias in additional_aliases]
                             )
 
-            # if aliases:
-            #     aliases = {k: list(set(v)) for k, v in aliases.items()}
+            if aliases:
+                aliases = {k: list(set(v)) for k, v in aliases.items()}
 
             # Extract genres and determine if anime
             genres_lower = [
@@ -338,7 +338,8 @@ class TVDBIndexer(BaseIndexer):
                             and translation.data.aliases
                         ):
                             additional_aliases = translation.data.aliases
-                            aliases["eng"].extend(
+
+                            aliases["us"].extend(
                                 [alias for alias in additional_aliases]
                             )
 


### PR DESCRIPTION
Because of this, the proxies set in `proxy_url` were never used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a potential crash when indexing show aliases: alias deduplication now runs only when aliases exist and translation aliases are mapped to the US alias list.

* **Refactor**
  * Standardized proxy handling across downloader services and simplified how proxy URLs are retrieved during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->