### PR TITLE
revert:"fix: probe media urls before adding to vfs"

### DIFF
--- a/src/program/apis/tvdb_api.py
+++ b/src/program/apis/tvdb_api.py
@@ -87,7 +87,6 @@ class TVDBApi:
                         logger.error("Failed to refresh expired TVDB token")
                         return None
                     logger.debug("Refreshed TVDB token")
-                    self._save_token_to_file(token)
                     return token
             return None
         except Exception as e:

--- a/src/program/services/filesystem/vfs/db.py
+++ b/src/program/services/filesystem/vfs/db.py
@@ -15,6 +15,7 @@ from program.services.streaming.exceptions import (
     DebridServiceLinkUnavailable,
 )
 from program.media.item import MediaItem
+from program.program import Program
 from program.types import Event
 from routers.secure.items import apply_item_mutation
 
@@ -316,7 +317,6 @@ class VFSDatabase:
         Returns:
             Dictionary with entry metadata and URLs, or None if not found
         """
-        from program.program import Program
 
         class GetEntryByOriginalFilenameResult(TypedDict):
             original_filename: str

--- a/src/program/services/filesystem/vfs/rivenvfs.py
+++ b/src/program/services/filesystem/vfs/rivenvfs.py
@@ -521,7 +521,6 @@ class RivenVFS(pyfuse3.Operations):
             True if successfully added, False otherwise
         """
         from program.media.media_entry import MediaEntry
-        from program.services.media_analysis import media_analysis_service
 
         # Only process if this item has a filesystem entry
         if not item.filesystem_entry:
@@ -532,39 +531,6 @@ class RivenVFS(pyfuse3.Operations):
         if not isinstance(entry, MediaEntry):
             logger.debug(f"Item {item.id} filesystem_entry is not a MediaEntry")
             return False
-
-        # Ensure we have an unrestricted URL available before analysis/VFS registration
-        if not getattr(entry, "unrestricted_url", None):
-            try:
-                if getattr(self, "vfs_db", None) and getattr(
-                    entry, "original_filename", None
-                ):
-                    resolved = self.vfs_db.get_entry_by_original_filename(
-                        original_filename=entry.original_filename,
-                        force_resolve=True,
-                    )
-                    if resolved and isinstance(resolved, dict):
-                        url = resolved.get("url") or resolved.get("unrestricted_url")
-                        if url:
-                            entry.unrestricted_url = url
-
-                    if not resolved:
-                        logger.debug(
-                            f"Failed to pre-resolve unrestricted URL for {item.log_string}"
-                        )
-                        return False
-            except Exception as e:
-                logger.debug(
-                    f"Failed to pre-resolve unrestricted URL for {item.log_string}: {e}"
-                )
-                return False
-
-        # add probed data
-        if media_analysis_service.should_submit(item):
-            success = media_analysis_service.run(item)
-            if not success:
-                logger.error(f"Failed to analyze media file for {item.log_string}")
-                return False
 
         # Register the MediaEntry (video file)
         video_paths = self._register_filesystem_entry(entry)


### PR DESCRIPTION
Reverts rivenmedia/riven#1274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized media analysis workflow to operate on local files instead of remote URLs
  * Restructured post-processing pipeline to run media analysis before subtitle processing
  * Simplified VFS registration by removing URL pre-resolution

* **Chores**
  * Adjusted TVDB token refresh behavior to no longer persist updated tokens to disk

<!-- end of auto-generated comment: release notes by coderabbit.ai -->