### PR TITLE
chore: change debrid log color to avoid confusion with error logs

### DIFF
--- a/src/program/utils/logging.py
+++ b/src/program/utils/logging.py
@@ -34,7 +34,7 @@ def setup_logger(level):
     log_levels = {
         "PROGRAM": (20, "cc6600", "🤖"),
         "DATABASE": (5, "d834eb", "🛢️"),  # trace
-        "DEBRID": (20, "cc3333", "🔗"),
+        "DEBRID": (20, "20B2AA", "🔗"),
         "FILESYSTEM": (5, "F9E79F", "🔗"),  # trace
         "VFS": (5, "9B59B6", "🧲"),  # trace
         "FUSE": (5, "999999", "⚙️"),  # trace


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [x] Added **tests** for changed code. (N/A)
- [X] Updated **documentation** for changed code. (N/A)

## Description:
* Currently the debrid logs look a lot like errors, since their red
* This turquoise color is unused in other logs, and is a bit less alarming. 

A small change, but good for my blood pressure :) 
