### PR TITLE
fix: add x-uuid header to log upload request to get a UUID paste name that's pretty much impossible to guess

### DIFF
--- a/src/routers/secure/default.py
+++ b/src/routers/secure/default.py
@@ -475,7 +475,7 @@ async def upload_logs() -> UploadLogsResponse:
         response = requests.post(
             "https://paste.c-net.org/",
             data=log_contents.encode("utf-8"),
-            headers={"Content-Type": "text/plain"},
+            headers={"Content-Type": "text/plain", "x-uuid": ""},
         )
 
         if response.status_code == 200:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the logging system's internal communication protocol.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->