### PR TITLE
fix: prowlarr tz awareness

### DIFF
--- a/src/program/services/scrapers/prowlarr.py
+++ b/src/program/services/scrapers/prowlarr.py
@@ -2,7 +2,7 @@
 
 import concurrent.futures
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
@@ -173,7 +173,7 @@ class Prowlarr(ScraperService[ProwlarrConfig]):
                 if (
                     status
                     and status.disabled_till
-                    and status.disabled_till > datetime.now()
+                    and status.disabled_till > datetime.now(timezone.utc)
                 ):
                     disabled_until = status.disabled_till.strftime("%Y-%m-%d %H:%M")
 
@@ -276,7 +276,7 @@ class Prowlarr(ScraperService[ProwlarrConfig]):
                 )
             )
 
-        self.last_indexer_scan = datetime.now()
+        self.last_indexer_scan = datetime.now(timezone.utc)
 
         return indexers
 
@@ -287,10 +287,11 @@ class Prowlarr(ScraperService[ProwlarrConfig]):
 
         if (
             self.last_indexer_scan is None
-            or (datetime.now() - self.last_indexer_scan).total_seconds() > 1800
+            or (datetime.now(timezone.utc) - self.last_indexer_scan).total_seconds()
+            > 1800
         ):
             self.indexers = self.get_indexers()
-            self.last_indexer_scan = datetime.now()
+            self.last_indexer_scan = datetime.now(timezone.utc)
 
             if len(self.indexers) != previous_count:
                 logger.info(


### PR DESCRIPTION
Fixes:

```log
`25-12-18 22:34:14 | ❌ ERROR     | prowlarr.run - Prowlarr failed to scrape item with error: can't compare offset-naive and offset-aware datetimes
Traceback (most recent call last):
  File "/riven/src/program/services/scrapers/prowlarr.py", line 313, in run
    return self.scrape(item)
  File "/riven/src/program/services/scrapers/prowlarr.py", line 326, in scrape
    self._periodic_indexer_scan()
  File "/riven/src/program/services/scrapers/prowlarr.py", line 292, in _periodic_indexer_scan
    self.indexers = self.get_indexers()
  File "/riven/src/program/services/scrapers/prowlarr.py", line 176, in get_indexers
    and status.disabled_till > datetime.now()
TypeError: can't compare offset-naive and offset-aware datetimes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of timezone-aware datetime comparisons in indexer status checks and periodic scan scheduling to ensure consistent UTC timing across scan operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->