### PR TITLE
feat: enable macOS development with pyfuse3 type stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "kink>=0.8.1,<0.9",
     "bencodepy>=0.9.5,<0.10",
     "plexapi>=4.17.1,<5",
-    "pyfuse3>=3.4.0,<4",
+    "pyfuse3>=3.4.0,<4; sys_platform == 'linux'",
     "babel>=2.17.0,<3",
     "httpx[http2,socks]>=0.28.1,<0.29",
     "starlette>=0.37.2",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,6 @@
 {
   "ignore": ["src/schemas", "src/tests", "src/alembic"],
+  "stubPath": "src/typings",
   "deprecateTypingAliases": true,
   "typeCheckingMode": "strict",
   "reportMissingTypeStubs": false,

--- a/src/typings/pyfuse3.pyi
+++ b/src/typings/pyfuse3.pyi
@@ -1,0 +1,103 @@
+"""
+Type stubs for pyfuse3.
+
+This stub file allows pyright/Pylance to type-check code that uses pyfuse3
+on platforms where pyfuse3 cannot be installed (macOS, Windows).
+
+Based on pyfuse3 v3.4.0. Update if pyfuse3 adds new APIs used by the codebase.
+"""
+
+from typing import Any, NewType, Set
+
+# Type aliases
+InodeT = NewType("InodeT", int)
+FileHandleT = NewType("FileHandleT", int)
+FileNameT = NewType("FileNameT", bytes)
+ModeT = NewType("ModeT", int)
+
+# Constants
+ROOT_INODE: InodeT
+default_options: Set[str]
+trio_token: Any
+
+class FUSEError(Exception):
+    errno: int
+    def __init__(self, errno: int = ...) -> None: ...
+
+class EntryAttributes:
+    st_ino: int
+    st_mode: int
+    st_nlink: int
+    st_uid: int
+    st_gid: int
+    st_size: int
+    st_atime_ns: int
+    st_mtime_ns: int
+    st_ctime_ns: int
+    st_blksize: int
+    st_blocks: int
+    generation: int
+    entry_timeout: float
+    attr_timeout: float
+
+class FileInfo:
+    fh: FileHandleT
+    def __init__(self, *, fh: FileHandleT = ...) -> None: ...
+
+class RequestContext:
+    uid: int
+    gid: int
+    pid: int
+
+class ReaddirToken: ...
+
+class Operations:
+    async def lookup(
+        self, parent_inode: InodeT, name: FileNameT, ctx: RequestContext
+    ) -> EntryAttributes: ...
+    async def getattr(
+        self, inode: InodeT, ctx: RequestContext
+    ) -> EntryAttributes: ...
+    async def opendir(self, inode: InodeT, ctx: RequestContext) -> FileHandleT: ...
+    async def readdir(
+        self, fh: FileHandleT, start_id: int, token: ReaddirToken
+    ) -> None: ...
+    async def releasedir(self, fh: FileHandleT) -> None: ...
+    async def open(
+        self, inode: InodeT, flags: int, ctx: RequestContext
+    ) -> FileInfo: ...
+    async def read(self, fh: FileHandleT, off: int, size: int) -> bytes: ...
+    async def release(self, fh: FileHandleT) -> None: ...
+    async def unlink(
+        self, parent_inode: InodeT, name: FileNameT, ctx: RequestContext
+    ) -> None: ...
+    async def rmdir(
+        self, parent_inode: InodeT, name: FileNameT, ctx: RequestContext
+    ) -> None: ...
+    async def rename(
+        self,
+        parent_inode_old: InodeT,
+        name_old: FileNameT,
+        parent_inode_new: InodeT,
+        name_new: FileNameT,
+        flags: int,
+        ctx: RequestContext,
+    ) -> None: ...
+
+def init(operations: Operations, mountpoint: str, options: Set[str]) -> None: ...
+async def main() -> None: ...
+def close(unmount: bool = ...) -> None: ...
+def terminate() -> None: ...
+def invalidate_inode(inode: InodeT, attr_only: bool = ...) -> None: ...
+def invalidate_entry_async(
+    parent_inode: InodeT,
+    name: FileNameT,
+    deleted: InodeT = ...,
+    ignore_enoent: bool = ...,
+) -> None: ...
+def readdir_reply(
+    token: ReaddirToken,
+    name: FileNameT,
+    attr: EntryAttributes,
+    next_id: int,
+) -> bool: ...

--- a/uv.lock
+++ b/uv.lock
@@ -1155,12 +1155,12 @@ wheels = [
 
 [[package]]
 name = "pyfuse3"
-version = "3.4.0"
+version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "trio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/1e/0f8f285a65e2e64f2f0c4accce4ee67d9ac66ee9684492a4327e48d68d87/pyfuse3-3.4.0.tar.gz", hash = "sha256:793493f4d5e2b3bc10e13b3421d426a6e2e3365264c24376a50b8cbc69762d39", size = 962992, upload-time = "2024-08-28T21:59:28.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/db/39003f19d6eb00fafc8210a8ee2703e58553c4c588f71ca413155fd43e32/pyfuse3-3.4.1.tar.gz", hash = "sha256:602f9c5f944bcdbd5e7f526c0e7f44af41970abedabc72d94ac16563e1b49209", size = 1185901, upload-time = "2025-12-22T21:22:27.019Z" }
 
 [[package]]
 name = "pygments"
@@ -1545,7 +1545,7 @@ dependencies = [
     { name = "psutil" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
-    { name = "pyfuse3" },
+    { name = "pyfuse3", marker = "sys_platform == 'linux'" },
     { name = "python-dotenv" },
     { name = "rank-torrent-name" },
     { name = "requests", extra = ["socks"] },
@@ -1610,7 +1610,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=7.1.0,<8" },
     { name = "psycopg2-binary", specifier = ">=2.9.9,<3" },
     { name = "pydantic", specifier = ">=2.12.0,<3" },
-    { name = "pyfuse3", specifier = ">=3.4.0,<4" },
+    { name = "pyfuse3", marker = "sys_platform == 'linux'", specifier = ">=3.4.0,<4" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
     { name = "rank-torrent-name", specifier = ">=1.9.3,<2" },
     { name = "requests", extras = ["socks"], specifier = ">=2.32.5,<3" },


### PR DESCRIPTION
# Pull Request Check List

Resolves: #1315

- [ ] Added **tests** for changed code.
Regression tested on a Linux machine. 
- [x] Updated **documentation** for changed code.

## Description:

This allows macOS developers to run uv sync, pyright, and use VS Code without type errors, while keeping pyfuse3 as a Linux-only runtime dependency.

  - Add platform marker to exclude pyfuse3 on non-Linux
  - Add type stubs for pyright/Pylance support
  - Configure pyrightconfig.json stubPath



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted pyfuse3 dependency to Linux platforms only.
  * Updated type checker configuration.

* **Documentation**
  * Added comprehensive type hints for the pyfuse3 library, improving code clarity, IDE support, and static type checking across all platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->