### PR TITLE
fix: refresh links on service unavailable

### DIFF
--- a/src/program/services/streaming/media_stream.py
+++ b/src/program/services/streaming/media_stream.py
@@ -857,7 +857,7 @@ class MediaStream:
                         continue
 
                     raise DebridServiceForbiddenException(provider=self.provider) from e
-                elif status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.GONE):
+                elif status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.GONE, HTTPStatus.SERVICE_UNAVAILABLE):
                     # File can't be found at this URL; try refreshing the URL once
                     if attempt == 0:
                         has_fresh_url = await self._refresh_download_url()


### PR DESCRIPTION
Resolves: #1334


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced streaming connection resilience by improving error handling during temporary service unavailability—the system now attempts to refresh and retry before failing, reducing interrupted playback from transient service issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->