### PR TITLE
fix: handle duplicate key errors in event processing pipeline

### DIFF
--- a/src/program/managers/event_manager.py
+++ b/src/program/managers/event_manager.py
@@ -147,6 +147,13 @@ class EventManager:
                     Event(emitted_by=service, item_id=item_id, run_at=timestamp)
                 )
         except Exception as e:
+            # Remove the event from running queue so it does not get stuck
+            if future_with_event.event:
+                self.remove_event_from_running(future_with_event.event)
+                logger.debug(
+                    f"Removed {future_with_event.event.log_message} from running events due to error."
+                )
+            
             logger.error(f"Error in future for {future_with_event}: {e}")
             logger.exception(traceback.format_exc())
 


### PR DESCRIPTION
## Problem
When adding large mdblist feeds (20k+ items), Riven encounters cascading `duplicate key value violates unique constraint` errors that block all new item additions and get the event queue stuck in an infinite error loop.

## Root Cause
When an IntegrityError occurred during database insertion, the event was logged as an error but never removed from the running events queue, causing it to be retried indefinitely and block processing of subsequent events.

## Solution
Modified the exception handler in `EventManager._process_future()` to remove failed events from the running queue, preventing them from getting stuck.

## Changes
- `src/program/managers/event_manager.py`: Added event removal on any exception in the futures callback

## Testing
- Tested with 31,624+ items in database
- 10 mdblist sources with 20k+ combined entries
- Continuous mdblist feed processing verified working

## Impact
✅ Events no longer get stuck when duplicate key errors occur
✅ mdblist feeds with 20k+ items now process without blocking
✅ System continues processing despite duplicate key constraint violations
✅ Allows concurrent item additions from multiple indexer/content sources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling to ensure events are properly cleaned up when errors occur, preventing them from becoming stuck or stalled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->