### PR TITLE
fix: auto-blacklist streams that return 451 Infringing Torrent

### DIFF
--- a/src/program/services/downloaders/__init__.py
+++ b/src/program/services/downloaders/__init__.py
@@ -17,6 +17,7 @@ from program.media.models import ActiveStream, MediaMetadata
 from program.services.downloaders.models import (
     DebridFile,
     DownloadedTorrent,
+    InfringingTorrentException,
     NoMatchingFilesException,
     NotCachedException,
     TorrentContainer,
@@ -181,6 +182,16 @@ class Downloader(Runner[None, DownloaderBase]):
                         # We want to retry this stream after cooldown
                         if len(self.initialized_services) == 1:
                             stream_failed_on_all_services = False
+                        continue
+
+                    except InfringingTorrentException as e:
+                        # 451 Infringing Torrent - immediately blacklist, do not retry
+                        # This is a permanent failure from the debrid service
+                        logger.warning(
+                            f"Stream {stream.infohash} flagged as infringing by {service.key}, blacklisting immediately"
+                        )
+                        item.blacklist_stream(stream)
+                        stream_failed_on_all_services = False  # Already handled via blacklist
                         continue
 
                     except Exception as e:

--- a/src/program/services/downloaders/models.py
+++ b/src/program/services/downloaders/models.py
@@ -68,6 +68,17 @@ class BitrateLimitExceededException(InvalidDebridFileException):
     """Exception raised when a file exceeds the allowed bitrate limit"""
 
 
+class InfringingTorrentException(Exception):
+    """Exception raised when debrid service returns 451 (infringing torrent).
+
+    This should trigger immediate blacklisting of the stream since the torrent
+    is permanently blocked by the debrid service and will never succeed.
+    """
+    def __init__(self, infohash: str):
+        self.infohash = infohash
+        super().__init__(f"Torrent {infohash} is flagged as infringing by debrid service")
+
+
 class DebridFile(BaseModel):
     """Represents a file from a debrid service"""
 

--- a/src/program/services/downloaders/realdebrid.py
+++ b/src/program/services/downloaders/realdebrid.py
@@ -12,6 +12,7 @@ from enum import IntEnum
 from program.services.downloaders.models import (
     VALID_VIDEO_EXTENSIONS,
     DebridFile,
+    InfringingTorrentException,
     InvalidDebridFileException,
     TorrentContainer,
     TorrentFile,
@@ -277,6 +278,7 @@ class RealDebridDownloader(DownloaderBase):
             raise
         except RealDebridError as e:
             # add_torrent/select_files/delete_torrent surface HTTP error context via _handle_error
+            error_msg = str(e)
             logger.warning(f"Availability check failed [{infohash}]: {e}")
 
             if torrent_id:
@@ -284,6 +286,11 @@ class RealDebridDownloader(DownloaderBase):
                     self.delete_torrent(torrent_id)
                 except Exception:
                     pass
+
+            # 451 = Infringing torrent - raise special exception for immediate blacklisting
+            # This is a permanent failure, the torrent will never work on this debrid service
+            if "[451]" in error_msg:
+                raise InfringingTorrentException(infohash)
 
             return None
         except InvalidDebridFileException as e:


### PR DESCRIPTION
## Summary

- When Real-Debrid returns HTTP 451 for a torrent (flagged as infringing), the stream is now immediately blacklisted
- Previously, these streams would continue to be retried indefinitely, wasting API calls and contributing to circuit breaker trips
- This is a permanent failure - once a torrent is flagged as infringing by the debrid service, it will never succeed

## Changes

1. **models.py**: Added `InfringingTorrentException` class to represent 451 errors with the infohash
2. **realdebrid.py**: Detect `[451]` in error messages and raise `InfringingTorrentException`
3. **__init__.py**: Catch `InfringingTorrentException` and immediately blacklist the stream

## Test plan

- [ ] Verify syntax with `python -m py_compile` on all modified files
- [ ] Test with a known infringing torrent hash to confirm blacklisting occurs
- [ ] Confirm circuit breaker no longer trips due to repeated 451 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of infringing torrents in the downloader service. When an infringing torrent is detected, it's now immediately blacklisted and the search continues with other services, rather than failing and retrying unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->