### PR TITLE
feat(calendar): return show ID for episode/season

### DIFF
--- a/src/program/db/db_functions.py
+++ b/src/program/db/db_functions.py
@@ -281,7 +281,7 @@ def create_calendar(session: Session | None = None) -> dict[int, dict[str, Any]]
 
         calendar = dict[int, dict[str, Any]]()
 
-        for item in result.scalars().all():
+        for item in result.scalars().yield_per(500):
             title = item.top_title
 
             # For episodes/seasons, use the parent show's IDs so the frontend
@@ -300,7 +300,7 @@ def create_calendar(session: Session | None = None) -> dict[int, dict[str, Any]]
                 "item_id": item.id,
                 "tvdb_id": show_tvdb_id,
                 "tmdb_id": show_tmdb_id,
-                "show_title": title,
+            bn,     "show_title": title,
                 "item_type": item.type,
                 "aired_at": item.aired_at,
                 "last_state": item.last_state,


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar now uses the parent show’s identifiers for episodes and seasons, ensuring consistent cross-referencing and correct navigation to show detail pages.
  * Maintains existing calendar fields (title, item type, air time, state, release/season/episode info) to preserve compatibility and display consistency.
  * Minor data consistency cleanup to reduce mismatches between calendar entries and show records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->