### PR TITLE
Add Support for Requested Seasons for Seer Webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,34 @@ findmnt -T /path/to/riven/mount -o TARGET,PROPAGATION  # expect: shared or rshar
 >- On SELinux systems, add :z to the bind mount if needed.
 
 
+## Overseerr Webhook Configuration
+
+If you are using Overseerr with the Webhook feature enabled (`RIVEN_CONTENT_OVERSEERR_USE_WEBHOOK=true`), you **must** configure the webhook JSON payload in Overseerr to pass the requested seasons. This ensures Riven correctly parses and downloads only the seasons that were explicitly requested.
+
+In your Overseerr Webhook settings, include the following in your JSON Payload:
+
+```json
+{
+  "notification_type": "{{notification_type}}",
+  "event": "{{event}}",
+  "subject": "{{subject}}",
+  "media": {
+    "media_type": "{{media_type}}",
+    "tmdbId": "{{media_tmdbid}}",
+    "tvdbId": "{{media_tvdbid}}",
+    "status": "{{media_status}}"
+  },
+  "extra": [
+    {
+      "name": "Requested Seasons",
+      "value": "{{requestedSeasons}}"
+    }
+  ]
+}
+```
+
+Riven requires the `"extra"` array to contain the exact name `"Requested Seasons"` paired with the `{{requestedSeasons}}` variable!
+
 ## Plex
 
 Plex libraries that are currently required to have sections:

--- a/src/program/services/indexers/base.py
+++ b/src/program/services/indexers/base.py
@@ -51,6 +51,7 @@ class BaseIndexer(Runner[IndexerModel]):
             item_a.set("seasons", item_b.seasons)
 
         if isinstance(item_b, Show) and item_a.type != "movie":
+            self.copy_attributes(item_a, item_b)
             for season_a in cast(Show, item_a).seasons:
                 for season_b in item_b.seasons:
                     if season_a.number == season_b.number:  # Check if seasons match

--- a/src/program/services/indexers/base.py
+++ b/src/program/services/indexers/base.py
@@ -36,6 +36,7 @@ class BaseIndexer(Runner[IndexerModel]):
             "active_stream",
             "requested_id",
             "streams",
+            "requested_seasons",
         ]
 
         for attr in attributes:

--- a/src/program/services/indexers/tvdb_indexer.py
+++ b/src/program/services/indexers/tvdb_indexer.py
@@ -46,7 +46,7 @@ class TVDBIndexer(BaseIndexer):
 
         # Scenario 1: Fresh indexing - create new Show from API data
         if item.type == "mediaitem":
-            if indexed_item := self._create_show_from_id(item.imdb_id, item.tvdb_id):
+            if indexed_item := self._create_show_from_id(item.imdb_id, item.tvdb_id, item):
                 indexed_item = self.copy_items(item, indexed_item)
                 indexed_item.indexed_at = datetime.now()
 
@@ -226,7 +226,7 @@ class TVDBIndexer(BaseIndexer):
             return False
 
     def _create_show_from_id(
-        self, imdb_id: str | None = None, tvdb_id: str | None = None
+        self, imdb_id: str | None = None, tvdb_id: str | None = None, item: MediaItem | None = None
     ) -> Show | None:
         """Create a show item from TVDB using available IDs."""
 
@@ -243,6 +243,8 @@ class TVDBIndexer(BaseIndexer):
                     show_item = self._map_show_from_tvdb_data(show_details, imdb_id)
 
                     if show_item:
+                        if item:
+                            setattr(show_item, "requested_seasons", getattr(item, "requested_seasons", None))
                         self._add_seasons_to_show(show_item, show_details)
 
                         return show_item
@@ -268,6 +270,8 @@ class TVDBIndexer(BaseIndexer):
                             )
 
                             if show_item:
+                                if item:
+                                    setattr(show_item, "requested_seasons", getattr(item, "requested_seasons", None))
                                 self._add_seasons_to_show(show_item, show_details)
                                 return show_item
                     else:

--- a/src/program/services/indexers/tvdb_indexer.py
+++ b/src/program/services/indexers/tvdb_indexer.py
@@ -416,6 +416,8 @@ class TVDBIndexer(BaseIndexer):
                 if season.number != 0 and season.type and season.type.type == "official"
             ]
 
+            requested_seasons = getattr(show, "requested_seasons", None)
+
             for season_data in filtered_seasons:
                 if season_data.id and (
                     extended_data := self.api.get_season(season_data.id)
@@ -435,11 +437,14 @@ class TVDBIndexer(BaseIndexer):
 
                         self._update_season_metadata(season_item, extended_data)
                     else:
-                        # Create new season
                         season_item = self._create_season_from_data(extended_data, show)
 
                         if not season_item:
                             continue
+                            
+                        if requested_seasons and season_item.number not in requested_seasons:
+                            from program.media.state import States
+                            season_item.last_state = States.Paused
 
                         show.add_season(season_item)
 

--- a/src/routers/secure/webhooks.py
+++ b/src/routers/secure/webhooks.py
@@ -6,6 +6,10 @@ from loguru import logger
 from program.media.item import MediaItem
 from program.services.content.overseerr import Overseerr
 from program.program import Program
+from program.db.db import db_session
+from program.db.db_functions import get_item_by_external_id
+from program.media.state import States
+from program.types import Event
 
 from ..models.overseerr import OverseerrWebhook
 
@@ -71,13 +75,43 @@ async def overseerr(request: Request) -> OverseerrWebhookResponse:
                 }
             )
         elif item_type == "tv":
+            tvdb_id = req.media.tvdbId
+            tmdb_id = req.media.tmdbId
+            requested_seasons = req.requested_seasons
+
+            with db_session() as session:
+                existing_show = get_item_by_external_id(
+                    tvdb_id=str(tvdb_id) if tvdb_id else None,
+                    tmdb_id=str(tmdb_id) if tmdb_id else None,
+                    session=session
+                )
+                
+                if existing_show:
+                    logger.info(f"Show {existing_show.log_string} already exists, handling requested seasons from overseerr")
+                    
+                    if requested_seasons:
+                        for season in existing_show.seasons: # type: ignore
+                            if getattr(season, "number", None) in requested_seasons and season.last_state == States.Paused:
+                                season.store_state(States.Requested)
+                                
+                                di[Program].em.add_event(Event(
+                                    emitted_by=Overseerr.__class__.__name__,
+                                    item_id=season.id
+                                ))
+                                
+                        session.commit()
+                        return OverseerrWebhookResponse(success=True)
+
             new_item = MediaItem(
                 {
-                    "tvdb_id": req.media.tvdbId,
+                    "tvdb_id": tvdb_id,
                     "requested_by": "overseerr",
                     "overseerr_id": req.request.request_id if req.request else None,
                 }
             )
+            
+            if requested_seasons:
+                new_item.set("requested_seasons", requested_seasons)
 
         if not new_item:
             logger.error(

--- a/src/tests/test_overseerr_webhook.py
+++ b/src/tests/test_overseerr_webhook.py
@@ -1,0 +1,39 @@
+import pytest
+from program.routers.models.overseerr import OverseerrWebhook
+
+def test_overseerr_webhook_requested_seasons():
+    payload = {
+        "notification_type": "TEST",
+        "event": "TEST_EVENT",
+        "subject": "Test",
+        "media": {
+            "media_type": "tv",
+            "tmdbId": 12345,
+            "status": "PENDING"
+        },
+        "extra": [
+            {
+                "name": "Requested Seasons",
+                "value": "1,2,5"
+            }
+        ]
+    }
+    
+    webhook = OverseerrWebhook(**payload)
+    assert webhook.requested_seasons == [1, 2, 5]
+
+def test_overseerr_webhook_requested_seasons_empty():
+    payload = {
+        "notification_type": "TEST",
+        "event": "TEST_EVENT",
+        "subject": "Test",
+        "media": {
+            "media_type": "tv",
+            "tmdbId": 12345,
+            "status": "PENDING"
+        },
+        "extra": []
+    }
+    
+    webhook = OverseerrWebhook(**payload)
+    assert webhook.requested_seasons is None


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

## Description:
Finishes piping through the optional requested seasons field for Seer Webhook notifications.  Initial implementation looked to be there but not fully integrated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for requesting specific TV seasons via Overseerr webhooks; requested seasons propagate to shows and new seasons not requested are left paused.
  * Re-requesting can promote previously paused seasons to requested state.

* **Tests**
  * Added unit tests validating parsing of requested seasons from Overseerr webhooks.

* **Documentation**
  * Added Overseerr webhook configuration guidance to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->