### PR TITLE
Revert "fix(alldebrid): correct magnet status response model and file extraction"

### DIFF
--- a/src/program/services/downloaders/alldebrid.py
+++ b/src/program/services/downloaders/alldebrid.py
@@ -6,17 +6,17 @@ from typing import Any, Generic, Literal, TypeVar, cast
 from loguru import logger
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
-from program.media.item import ProcessedItemType
 from program.services.downloaders.models import (
     DebridFile,
     InvalidDebridFileException,
     TorrentContainer,
     TorrentInfo,
-    UnrestrictedLink,
     UserInfo,
+    UnrestrictedLink,
 )
 from program.settings import settings_manager
 from program.utils.request import CircuitBreakerOpen, SmartResponse, SmartSession
+from program.media.item import ProcessedItemType
 
 from .shared import DownloaderBase, premium_days_left
 
@@ -26,7 +26,7 @@ class AllDebridFile(BaseModel):
 
     n: str  # Name
     s: int  # Size in bytes
-    l: str = ""  # noqa: E741  # Download link
+    l: str  # Download link
 
 
 class AllDebridDirectory(BaseModel):
@@ -77,11 +77,7 @@ class AllDebridMagnet(BaseModel):
         size: int
         ready: bool
 
-    class MagnetErrorInfo(BaseModel):
-        magnet: str
-        error: str | AllDebridErrorDetail
-
-    magnets: list[MagnetInfo | MagnetErrorInfo]
+    magnets: list[MagnetInfo]
 
 
 class AllDebridUserResponse(BaseModel):
@@ -116,7 +112,7 @@ class AllDebridMagnetStatusResponse(BaseModel):
         status_code: int = Field(alias="statusCode")
         upload_date: int = Field(alias="uploadDate")
         completion_date: int = Field(alias="completionDate")
-        files: list[AllDebridFile | AllDebridDirectory] | None = None
+        files: list[AllDebridFile | AllDebridDirectory] | None
 
     class MagnetErrorInfo(BaseModel):
         id: str
@@ -127,6 +123,8 @@ class AllDebridMagnetStatusResponse(BaseModel):
     @field_validator("magnets", mode="before")
     @classmethod
     def normalize_magnets(cls, v: Any):
+        logger.debug(f"Normalizing magnets field: {v}")
+
         if isinstance(v, dict):
             return cast(list[dict[Any, Any]], [v])
 
@@ -341,7 +339,7 @@ class AllDebridDownloader(DownloaderBase):
 
             raise
         except AllDebridError as e:
-            logger.debug(f"Availability check failed [{infohash}]: {e}")
+            logger.warning(f"Availability check failed [{infohash}]: {e}")
 
             if torrent_id:
                 try:
@@ -447,7 +445,8 @@ class AllDebridDownloader(DownloaderBase):
                         s=file_obj.s,
                         l=(
                             # Use the file's own link if present, otherwise inherit from parent
-                            file_obj.l or download_link
+                            file_obj.l
+                            or download_link
                         ),
                     )
                 )
@@ -542,14 +541,6 @@ class AllDebridDownloader(DownloaderBase):
 
         [magnet_info] = magnets
 
-        if isinstance(magnet_info, AllDebridMagnet.MagnetErrorInfo):
-            err = (
-                magnet_info.error
-                if isinstance(magnet_info.error, str)
-                else magnet_info.error.message
-            )
-            raise AllDebridError(f"Magnet rejected by AllDebrid: {err}")
-
         magnet_id = magnet_info.id
 
         if not magnet_id:
@@ -610,14 +601,28 @@ class AllDebridDownloader(DownloaderBase):
                 return None
 
             for magnet in magnets:
+                # Extract files from links in the status response
+                # Structure: links[].link = download URL, links[].files = file/folder objects
+                # For season packs: links[].files[0].e = array of episode files
+
                 if isinstance(magnet, AllDebridMagnetStatusResponse.MagnetErrorInfo):
-                    continue
+                    continue  # Skip errored magnets
 
                 files = magnet.files
 
                 if files:
-                    all_files: list[AllDebridFile] = []
-                    self._add_link_to_files_recursive(files, "", all_files)
+                    all_files = list[AllDebridFile]()
+
+                    for file_or_directory in files:
+                        download_link = ""
+
+                        if isinstance(file_or_directory, AllDebridFile):
+                            download_link = file_or_directory.l
+                        else:
+                            # Recursively process files/folders and add download link
+                            self._add_link_to_files_recursive(
+                                file_or_directory.e, download_link, all_files
+                            )
 
                     if all_files:
                         return all_files

--- a/src/tests/test_alldebrid_downloader.py
+++ b/src/tests/test_alldebrid_downloader.py
@@ -1,206 +1,176 @@
-import json
-from pathlib import Path
-from unittest.mock import MagicMock
+# import json
 
-from program.services.downloaders.alldebrid import (
-    AllDebridAPI,
-    AllDebridDirectory,
-    AllDebridDownloader,
-    AllDebridFile,
-    AllDebridMagnet,
-    AllDebridMagnetStatusResponse,
-    AllDebridResponse,
-)
+# import pytest
 
-TEST_DATA = Path(__file__).parent / "test_data"
+# from program.services.downloaders import alldebrid
+# from program.services.downloaders.alldebrid import (
+#     AllDebridDownloader,
+#     add_torrent,
+#     get_instant_availability,
+#     get_status,
+#     get_torrents,
+# )
+# from program.settings.manager import settings_manager as settings
 
 
-def load_fixture(name: str) -> dict:
-    with open(TEST_DATA / name) as f:
-        return json.load(f)
+# @pytest.fixture
+# def downloader(instant, upload, status, status_all, delete):
+#     """Instance of AllDebridDownloader with API calls mocked"""
+#     # mock API calls
+#     _get = alldebrid.get
+#     def get(url, **params):
+#         match url:
+#             case "user":
+#                 return {"data": { "user": { "isPremium": True, "premiumUntil": 1735514599, } } }
+#             case "magnet/instant":
+#                 return instant(url, **params)
+#             case "magnet/upload":
+#                 return upload(url, **params)
+#             case "magnet/delete":
+#                 return delete(url, **params)
+#             case "magnet/status":
+#                 if params.get("id", False):
+#                     return status(url, **params)
+#                 else:
+#                     return status_all(url, **params)
+#             case _:
+#                 raise Exception("unmatched api call")
+#     alldebrid.get = get
+
+#     alldebrid_settings = settings.settings.downloaders.all_debrid
+#     alldebrid_settings.enabled = True
+#     alldebrid_settings.api_key = "key"
+
+#     downloader = AllDebridDownloader()
+#     assert downloader.initialized
+#     yield downloader
+
+#     # tear down mock
+#     alldebrid.get = get
 
 
-def make_mock_response(json_body: dict, status_code: int = 200) -> MagicMock:
-    resp = MagicMock()
-    resp.ok = status_code < 400
-    resp.status_code = status_code
-    resp.json.return_value = json_body
-    return resp
+# ## Downloader tests
+# def test_process_hashes(downloader):
+#     hashes = downloader.process_hashes(["abc"], None, [False, True])
+#     assert len(hashes) == 1
 
 
-def make_downloader() -> AllDebridDownloader:
-    """Construct an AllDebridDownloader without triggering __init__ settings validation."""
-    downloader = object.__new__(AllDebridDownloader)
-    downloader.key = "alldebrid"
-    downloader.api = MagicMock()
-    return downloader
+# def test_download_cached(downloader):
+#     torrent_id = downloader.download_cached({"infohash": "abc"})
+#     assert torrent_id == MAGNET_ID
 
 
-# --- Model parsing ---
+# def test_get_torrent_names(downloader):
+#     names = downloader.get_torrent_names(123)
+#     assert names == ("Ubuntu 24.04", None)
 
 
-def test_status_response_parses_files():
-    """MagnetInfo.files is populated from the v4.1 API 'files' field."""
-    body = load_fixture("alldebrid_magnet_status_one_ready.json")
-    parsed = AllDebridResponse[AllDebridMagnetStatusResponse].model_validate(
-        {"data": body}
-    )
-    magnets = parsed.data.data.magnets
-    assert len(magnets) == 1
-    magnet = magnets[0]
-    assert isinstance(magnet, AllDebridMagnetStatusResponse.MagnetInfo)
-    assert magnet.files is not None
-    assert len(magnet.files) == 2
-    assert isinstance(magnet.files[0], AllDebridFile)
-    assert magnet.files[0].n == "ubuntu-24.04-desktop-amd64.iso"
-    assert magnet.files[0].l == "https://alldebrid.com/f/REDACTED"
+# ## API parsing tests
+# def test_get_instant_availability(instant):
+#     alldebrid.get = instant
+#     infohashes = [UBUNTU]
+#     availability = get_instant_availability(infohashes)
+#     assert len(availability[0].get("files", [])) == 2
 
 
-def test_status_response_normalizes_single_magnet_dict_to_list():
-    """normalize_magnets wraps a bare dict (single magnet) into a list."""
-    body = load_fixture("alldebrid_magnet_status_one_ready.json")
-    parsed = AllDebridResponse[AllDebridMagnetStatusResponse].model_validate(
-        {"data": body}
-    )
-    assert len(parsed.data.data.magnets) == 1
+# def test_get_instant_availability_unavailable(instant_unavailable):
+#     alldebrid.get = instant_unavailable
+#     infohashes = [UBUNTU]
+#     availability = get_instant_availability(infohashes)
+#     assert availability[0]["hash"] == UBUNTU
 
 
-def test_status_response_downloading_has_no_files():
-    body = load_fixture("alldebrid_magnet_status_one_downloading.json")
-    parsed = AllDebridResponse[AllDebridMagnetStatusResponse].model_validate(
-        {"data": body}
-    )
-    magnet = parsed.data.data.magnets[0]
-    assert isinstance(magnet, AllDebridMagnetStatusResponse.MagnetInfo)
-    assert magnet.status == "Downloading"
-    assert magnet.files is None
+# def test_add_torrent(upload):
+#     alldebrid.get = upload
+#     torrent_id = add_torrent(UBUNTU)
+#     assert torrent_id == 251993753
 
 
-def test_upload_response_parses_error_entry():
-    """AllDebridMagnet.MagnetErrorInfo is parsed when AllDebrid rejects a magnet."""
-    body = {
-        "status": "success",
-        "data": {
-            "magnets": [
-                {
-                    "magnet": "magnet:?xt=urn:btih:invalid",
-                    "error": "This is not a valid torrent",
-                }
-            ]
-        },
-    }
-    parsed = AllDebridResponse[AllDebridMagnet].model_validate({"data": body})
-    magnets = parsed.data.data.magnets
-    assert len(magnets) == 1
-    assert isinstance(magnets[0], AllDebridMagnet.MagnetErrorInfo)
-    assert magnets[0].error == "This is not a valid torrent"
+# def test_add_torrent_cached(upload_ready):
+#     alldebrid.get = upload_ready
+#     torrent_id = add_torrent(UBUNTU)
+#     assert torrent_id == 251993753
 
 
-# --- _get_magnet_files ---
+# def test_get_status(status):
+#     alldebrid.get = status
+#     torrent_status = get_status(251993753)
+#     assert torrent_status["filename"] == "Ubuntu 24.04"
 
 
-def test_get_magnet_files_extracts_flat_ready_magnet():
-    downloader = make_downloader()
-    body = load_fixture("alldebrid_magnet_status_one_ready.json")
-    downloader.api.session.post.return_value = make_mock_response(body)
-
-    result = downloader._get_magnet_files(251993753)
-
-    assert result is not None
-    assert len(result) == 2
-    assert result[0].n == "ubuntu-24.04-desktop-amd64.iso"
-    assert result[0].s == 6114656256
-    assert result[0].l == "https://alldebrid.com/f/REDACTED"
+# def test_get_status_unfinished(status_downloading):
+#     alldebrid.get = status_downloading
+#     torrent_status = get_status(251993753)
+#     assert torrent_status["status"] == "Downloading"
 
 
-def test_get_magnet_files_extracts_nested_directory():
-    """Files inside a directory in files[] are extracted recursively with their own links."""
-    downloader = make_downloader()
-    body = {
-        "status": "success",
-        "data": {
-            "magnets": {
-                "id": 3,
-                "filename": "Show.S01",
-                "size": 3_000_000_000,
-                "status": "Ready",
-                "statusCode": 4,
-                "uploadDate": 1727454272,
-                "completionDate": 1727454803,
-                "files": [
-                    {
-                        "n": "Show Season 1",
-                        "e": [
-                            {
-                                "n": "Show.S01E01.mkv",
-                                "s": 1_500_000_000,
-                                "l": "https://alldebrid.com/f/EP1",
-                            },
-                            {
-                                "n": "Show.S01E02.mkv",
-                                "s": 1_500_000_000,
-                                "l": "https://alldebrid.com/f/EP2",
-                            },
-                        ],
-                    }
-                ],
-            }
-        },
-    }
-    downloader.api.session.post.return_value = make_mock_response(body)
-
-    result = downloader._get_magnet_files(3)
-
-    assert result is not None
-    assert len(result) == 2
-    assert result[0].n == "Show.S01E01.mkv"
-    assert result[0].l == "https://alldebrid.com/f/EP1"
-    assert result[1].n == "Show.S01E02.mkv"
-    assert result[1].l == "https://alldebrid.com/f/EP2"
+# def test_get_torrents(status_all):
+#     alldebrid.get = status_all
+#     torrents = get_torrents()
+#     assert torrents[0]["status"] == "Ready"
 
 
-def test_get_magnet_files_returns_none_when_not_ready():
-    """Returns None when the magnet has no files (still downloading)."""
-    downloader = make_downloader()
-    body = load_fixture("alldebrid_magnet_status_one_downloading.json")
-    downloader.api.session.post.return_value = make_mock_response(body)
-
-    result = downloader._get_magnet_files(251993753)
-
-    assert result is None
+# def test_delete(delete):
+#     alldebrid.get = delete
+#     delete(123)
 
 
-def test_get_magnet_files_returns_none_on_http_error():
-    downloader = make_downloader()
-    downloader.api.session.post.return_value = make_mock_response({}, status_code=500)
+# # Example requests - taken from real API calls
+# UBUNTU = "3648baf850d5930510c1f172b534200ebb5496e6"
+# MAGNET_ID = "251993753"
+# @pytest.fixture
+# def instant():
+#     """GET /magnet/instant?magnets[0]=infohash (torrent available)"""
+#     with open("src/tests/test_data/alldebrid_magnet_instant.json") as f:
+#         body = json.load(f)
+#     return lambda url, **params: body
 
-    result = downloader._get_magnet_files(999)
+# @pytest.fixture
+# def instant_unavailable():
+#     """GET /magnet/instant?magnets[0]=infohash (torrent unavailable)"""
+#     with open("src/tests/test_data/alldebrid_magnet_instant_unavailable.json") as f:
+#         body = json.load(f)
+#     return lambda url, **params: body
 
-    assert result is None
+# @pytest.fixture
+# def upload():
+#     """GET /magnet/upload?magnets[]=infohash (torrent not ready yet)"""
+#     with open("src/tests/test_data/alldebrid_magnet_upload_not_ready.json") as f:
+#         body = json.load(f)
+#     return lambda url, **params: body
 
+# @pytest.fixture
+# def upload_ready():
+#     """GET /magnet/upload?magnets[]=infohash (torrent ready)"""
+#     with open("src/tests/test_data/alldebrid_magnet_upload_ready.json") as f:
+#         body = json.load(f)
+#     return lambda url, **params: body
 
-# --- get_torrent_info ---
+# @pytest.fixture
+# def status():
+#     """GET /magnet/status?id=123 (debrid links ready)"""
+#     with open("src/tests/test_data/alldebrid_magnet_status_one_ready.json") as f:
+#         body = json.load(f)
+#     return lambda url, **params: body
 
+# @pytest.fixture
+# def status_downloading():
+#     """GET /magnet/status?id=123 (debrid links not ready yet)"""
+#     with open("src/tests/test_data/alldebrid_magnet_status_one_downloading.json") as f:
+#         body = json.load(f)
+#     return lambda url, **params: body
 
-def test_get_torrent_info_ready():
-    downloader = make_downloader()
-    body = load_fixture("alldebrid_magnet_status_one_ready.json")
-    downloader.api.session.post.return_value = make_mock_response(body)
+# @pytest.fixture
+# def status_all():
+#     """GET /magnet/status (gets a list of all links instead of a single object)"""
+#     # The body is the same as a single item, but with all your magnets in a list.
+#     with open("src/tests/test_data/alldebrid_magnet_status_one_ready.json") as f:
+#         body = json.load(f)
+#     return lambda url, **params: {"status": "success", "data": {"magnets": [body["data"]["magnets"]]}}
 
-    info = downloader.get_torrent_info(251993753)
-
-    assert info.name == "Ubuntu 24.04"
-    assert info.status == "Ready"
-    assert info.bytes == 8869638144
-    assert info.progress == 100.0
-
-
-def test_get_torrent_info_downloading():
-    downloader = make_downloader()
-    body = load_fixture("alldebrid_magnet_status_one_downloading.json")
-    downloader.api.session.post.return_value = make_mock_response(body)
-
-    info = downloader.get_torrent_info(251993753)
-
-    assert info.status == "Downloading"
-    assert info.progress == 0.0
+# @pytest.fixture
+# def delete():
+#     """GET /delete"""
+#     with open("src/tests/test_data/alldebrid_magnet_delete.json") as f:
+#         body = json.load(f)
+#     return lambda url, **params: body

--- a/src/tests/test_data/alldebrid_magnet_status_one_downloading.json
+++ b/src/tests/test_data/alldebrid_magnet_status_one_downloading.json
@@ -16,6 +16,7 @@
             "uploadSpeed": 0,
             "uploadDate": 1727454272,
             "completionDate": 0,
+            "links": [],
             "type": "m",
             "notified": false,
             "version": 2

--- a/src/tests/test_data/alldebrid_magnet_status_one_ready.json
+++ b/src/tests/test_data/alldebrid_magnet_status_one_ready.json
@@ -16,9 +16,21 @@
             "uploadSpeed": 0,
             "uploadDate": 1727454272,
             "completionDate": 1727454803,
-            "files": [
-                {"n": "ubuntu-24.04-desktop-amd64.iso", "s": 6114656256, "l": "https://alldebrid.com/f/REDACTED"},
-                {"n": "ubuntu-24.04-live-server-amd64.iso", "s": 2754981888, "l": "https://alldebrid.com/f/REDACTED2"}
+            "links": [
+                {
+                    "filename": "ubuntu-24.04-desktop-amd64.iso",
+                    "size": 6114656256,
+                    "files": [{"n": "ubuntu-24.04-desktop-amd64.iso", "s": 6114656256}],
+                    "link": "https://alldebrid.com/f/REDACTED"
+                },
+                {
+                    "filename": "ubuntu-24.04-live-server-amd64.iso",
+                    "size": 2754981888,
+                    "files": [
+                        {"n": "ubuntu-24.04-live-server-amd64.iso", "s": 2754981888}
+                    ],
+                    "link": "https://alldebrid.com/f/REDACTED"
+                }
             ],
             "type": "m",
             "notified": false,


### PR DESCRIPTION
Reverts rivenmedia/riven#1407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of downloadable files from magnet results, including nested folders and inherited file links.
  * Made torrent status handling more reliable by treating missing file information consistently.
  * Adjusted error reporting so instant-availability failures are surfaced more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->